### PR TITLE
Scan only the src folder for secrets

### DIFF
--- a/.github/workflows/secrets_scan.yml
+++ b/.github/workflows/secrets_scan.yml
@@ -13,5 +13,5 @@ jobs:
           fetch-depth: 0
       - uses: trufflesecurity/trufflehog@main
         with:
-          path: ./
+          path: ./src
           base: ${{ github.event.repository.default_branch }}


### PR DESCRIPTION
### Issue

Trufflehog is incorrectly detecting secrets in yarn

Example run: https://github.com/aws/aws-sdk-js-codemod/actions/runs/7888553976/job/21526340541?pr=756

### Description

Scan only the src folder for secrets

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
