### PR TITLE
Switch to eslint flat config

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,4 +1,5 @@
 // @ts-check
+/* eslint-disable @typescript-eslint/naming-convention */
 
 import eslint from "@eslint/js";
 import tseslint from "typescript-eslint";

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -16,10 +16,18 @@ export default tseslint.config({
     },
   },
   rules: {
-    "@typescript-eslint/no-unsafe-argument": "error",
-    "@typescript-eslint/no-unsafe-assignment": "error",
-    "@typescript-eslint/no-unsafe-call": "error",
-    "@typescript-eslint/no-unsafe-member-access": "error",
-    "@typescript-eslint/no-unsafe-return": "error",
+    "import/order": ["error", { alphabetize: { order: "asc" } }],
+    "import/first": "error",
+    "import/no-mutable-exports": "error",
+    "import/no-unresolved": "off",
+    "@typescript-eslint/array-type": ["error", { default: "array" }],
+    "@typescript-eslint/naming-convention": [
+      "error",
+      {
+        selector: "default",
+        format: ["camelCase", "UPPER_CASE", "PascalCase"],
+        leadingUnderscore: "allow",
+      },
+    ],
   },
 });

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,23 @@
+// @ts-check
+
+import eslint from "@eslint/js";
+import tseslint from "typescript-eslint";
+
+export default tseslint.config({
+  plugins: {
+    "@typescript-eslint": tseslint.plugin,
+  },
+  languageOptions: {
+    parser: tseslint.parser,
+    parserOptions: {
+      project: true,
+    },
+  },
+  rules: {
+    "@typescript-eslint/no-unsafe-argument": "error",
+    "@typescript-eslint/no-unsafe-assignment": "error",
+    "@typescript-eslint/no-unsafe-call": "error",
+    "@typescript-eslint/no-unsafe-member-access": "error",
+    "@typescript-eslint/no-unsafe-return": "error",
+  },
+});

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -4,6 +4,7 @@ import eslint from "@eslint/js";
 import tseslint from "typescript-eslint";
 
 export default tseslint.config({
+  files: ["src/**/*.ts"],
   plugins: {
     "@typescript-eslint": tseslint.plugin,
   },

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -5,6 +5,7 @@ import tseslint from "typescript-eslint";
 
 export default tseslint.config({
   files: ["src/**/*.ts"],
+  extends: [eslint.configs.recommended, ...tseslint.configs.recommended],
   plugins: {
     "@typescript-eslint": tseslint.plugin,
   },

--- a/package.json
+++ b/package.json
@@ -46,8 +46,6 @@
     "@tsconfig/node14": "^1.0.3",
     "@types/jscodeshift": "^0.11.5",
     "@types/node": "^14.18.33",
-    "@typescript-eslint/eslint-plugin": "^7.0.1",
-    "@typescript-eslint/parser": "^7.0.1",
     "aws-sdk": "2.1495.0",
     "eslint": "^8.56.0",
     "eslint-plugin-import": "^2.29.0",
@@ -56,6 +54,7 @@
     "simple-git-hooks": "^2.8.1",
     "tsx": "^3.12.1",
     "typescript": "~5.3.2",
+    "typescript-eslint": "^7.0.1",
     "vitest": "~1.0.1"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "scripts": {
     "build": "tsc",
-    "lint": "eslint 'src/**/*.ts'",
+    "lint": "ESLINT_USE_FLAT_CONFIG=true eslint 'src/**/*.ts'",
     "release": "yarn build && changeset publish",
     "test": "vitest"
   },

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "scripts": {
     "build": "tsc",
-    "lint": "ESLINT_USE_FLAT_CONFIG=true eslint 'src/**/*.ts'",
+    "lint": "ESLINT_USE_FLAT_CONFIG=true eslint 'src/**/*.ts' -c eslint.config.mjs",
     "release": "yarn build && changeset publish",
     "test": "vitest"
   },

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "scripts": {
     "build": "tsc",
-    "lint": "ESLINT_USE_FLAT_CONFIG=true eslint 'src/**/*.ts' -c eslint.config.mjs",
+    "lint": "ESLINT_USE_FLAT_CONFIG=true eslint -c eslint.config.mjs",
     "release": "yarn build && changeset publish",
     "test": "vitest"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1433,7 +1433,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/eslint-plugin@npm:^7.0.1":
+"@typescript-eslint/eslint-plugin@npm:7.0.1":
   version: 7.0.1
   resolution: "@typescript-eslint/eslint-plugin@npm:7.0.1"
   dependencies:
@@ -1458,7 +1458,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/parser@npm:^7.0.1":
+"@typescript-eslint/parser@npm:7.0.1":
   version: 7.0.1
   resolution: "@typescript-eslint/parser@npm:7.0.1"
   dependencies:
@@ -1899,8 +1899,6 @@ __metadata:
     "@tsconfig/node14": "npm:^1.0.3"
     "@types/jscodeshift": "npm:^0.11.5"
     "@types/node": "npm:^14.18.33"
-    "@typescript-eslint/eslint-plugin": "npm:^7.0.1"
-    "@typescript-eslint/parser": "npm:^7.0.1"
     aws-sdk: "npm:2.1495.0"
     eslint: "npm:^8.56.0"
     eslint-plugin-import: "npm:^2.29.0"
@@ -1910,6 +1908,7 @@ __metadata:
     simple-git-hooks: "npm:^2.8.1"
     tsx: "npm:^3.12.1"
     typescript: "npm:~5.3.2"
+    typescript-eslint: "npm:^7.0.1"
     vitest: "npm:~1.0.1"
   bin:
     aws-sdk-js-codemod: bin/aws-sdk-js-codemod
@@ -3644,10 +3643,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ignore@npm:^5.2.0, ignore@npm:^5.2.4":
+"ignore@npm:^5.2.0":
   version: 5.3.0
   resolution: "ignore@npm:5.3.0"
   checksum: 10c0/dc06bea5c23aae65d0725a957a0638b57e235ae4568dda51ca142053ed2c352de7e3bc93a69b2b32ac31966a1952e9a93c5ef2e2ab7c6b06aef9808f6b55b571
+  languageName: node
+  linkType: hard
+
+"ignore@npm:^5.2.4":
+  version: 5.3.1
+  resolution: "ignore@npm:5.3.1"
+  checksum: 10c0/703f7f45ffb2a27fb2c5a8db0c32e7dee66b33a225d28e8db4e1be6474795f606686a6e3bcc50e1aa12f2042db4c9d4a7d60af3250511de74620fbed052ea4cd
   languageName: node
   linkType: hard
 
@@ -5562,7 +5568,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:^7.3.5, semver@npm:^7.5.3, semver@npm:^7.5.4":
+"semver@npm:^7.3.5, semver@npm:^7.5.3":
   version: 7.5.4
   resolution: "semver@npm:7.5.4"
   dependencies:
@@ -5570,6 +5576,17 @@ __metadata:
   bin:
     semver: bin/semver.js
   checksum: 10c0/5160b06975a38b11c1ab55950cb5b8a23db78df88275d3d8a42ccf1f29e55112ac995b3a26a522c36e3b5f76b0445f1eef70d696b8c7862a2b4303d7b0e7609e
+  languageName: node
+  linkType: hard
+
+"semver@npm:^7.5.4":
+  version: 7.6.0
+  resolution: "semver@npm:7.6.0"
+  dependencies:
+    lru-cache: "npm:^6.0.0"
+  bin:
+    semver: bin/semver.js
+  checksum: 10c0/fbfe717094ace0aa8d6332d7ef5ce727259815bd8d8815700853f4faf23aacbd7192522f0dc5af6df52ef4fa85a355ebd2f5d39f554bd028200d6cf481ab9b53
   languageName: node
   linkType: hard
 
@@ -6088,11 +6105,11 @@ __metadata:
   linkType: hard
 
 "ts-api-utils@npm:^1.0.1":
-  version: 1.0.3
-  resolution: "ts-api-utils@npm:1.0.3"
+  version: 1.2.1
+  resolution: "ts-api-utils@npm:1.2.1"
   peerDependencies:
     typescript: ">=4.2.0"
-  checksum: 10c0/9408338819c3aca2a709f0bc54e3f874227901506cacb1163612a6c8a43df224174feb965a5eafdae16f66fc68fd7bfee8d3275d0fa73fbb8699e03ed26520c9
+  checksum: 10c0/8ddb493e7ae581d3f57a2e469142feb60b420d4ad8366ab969fe8e36531f8f301f370676b47e8d97f28b5f5fd10d6f2d55f656943a8546ef95e35ce5cf117754
   languageName: node
   linkType: hard
 
@@ -6244,6 +6261,21 @@ __metadata:
     for-each: "npm:^0.3.3"
     is-typed-array: "npm:^1.1.9"
   checksum: 10c0/c5163c0103d07fefc8a2ad0fc151f9ca9a1f6422098c00f695d55f9896e4d63614cd62cf8d8a031c6cee5f418e8980a533796597174da4edff075b3d275a7e23
+  languageName: node
+  linkType: hard
+
+"typescript-eslint@npm:^7.0.1":
+  version: 7.0.1
+  resolution: "typescript-eslint@npm:7.0.1"
+  dependencies:
+    "@typescript-eslint/eslint-plugin": "npm:7.0.1"
+    "@typescript-eslint/parser": "npm:7.0.1"
+  peerDependencies:
+    eslint: ^8.56.0
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10c0/f0108b61ca942319a979494eb2960c439db503a3e4bcca8e1ec5fe58a84948646a5bd52cb04bffa0b1fee528675c276705964ad89db8c7d5bced27c5cfb8e797
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Issue

Blog post: https://eslint.org/blog/2022/08/new-config-system-part-2/

Flat config is going to be the default in eslint v9.x
https://eslint.org/blog/2023/11/whats-coming-in-eslint-9.0.0/#flat-config-now-the-default-and-has-some-changes

Docs:
* Flat config: https://eslint.org/docs/latest/use/configure/configuration-files-new
* Migration to flat config: https://eslint.org/docs/latest/use/configure/migration-guide
* typescript-eslint flat config support: https://typescript-eslint.io/blog/announcing-typescript-eslint-v7/#new-features---flat-config-support

### Description

Switch to eslint flat config

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
