### PR TITLE
Set source.fixAll.eslint=explicit in VSCode settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": "explicit"
   },
   "editor.formatOnSave": true,
   "editor.defaultFormatter": "esbenp.prettier-vscode",


### PR DESCRIPTION
### Issue

The change is done automatically by extension, likely introduced by https://github.com/microsoft/vscode-eslint/pull/1756 in v2.4.4

### Description

Set source.fixAll.eslint=explicit in VSCode settings

### Testing

Verified that eslint is run on file save

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
