### PR TITLE
Explicitly pass all extensions by default when calling jscodeshift

### DIFF
--- a/.changeset/nice-windows-swim.md
+++ b/.changeset/nice-windows-swim.md
@@ -1,0 +1,5 @@
+---
+"aws-sdk-js-codemod": patch
+---
+
+Explicitly pass all extensions by default when calling jscodeshift

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -45,7 +45,9 @@ if (args[2] === "--help" || args[2] === "-h") {
 if (!args.some((arg) => arg.startsWith("--extensions"))) {
   // Explicitly add all extensions as default to avoid bug in jscodeshift.
   // Refs: https://github.com/facebook/jscodeshift/blob/51da1a5c4ba3707adb84416663634d4fc3141cbb/src/Worker.js#L80
-  const babelExtensions = DEFAULT_EXTENSIONS.map((ext) => ext.substring(1));
+  const babelExtensions = DEFAULT_EXTENSIONS.map((ext) =>
+    ext.startsWith(".") ? ext.substring(1) : ext
+  );
   args.push(`--extensions=${[...babelExtensions, "ts", "tsx"].join(",")}`);
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -24,6 +24,7 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 import path from "path";
+import { DEFAULT_EXTENSIONS } from "@babel/core";
 import Runner from "jscodeshift/dist/Runner";
 
 import {
@@ -38,6 +39,14 @@ const transforms = getTransforms();
 
 if (args[2] === "--help" || args[2] === "-h") {
   process.stdout.write(getHelpParagraph(transforms));
+}
+
+// Refs: https://github.com/facebook/jscodeshift/issues/582
+if (!args.some((arg) => arg.startsWith("--extensions"))) {
+  // Explicitly add all extensions as default to avoid bug in jscodeshift.
+  // Refs: https://github.com/facebook/jscodeshift/blob/51da1a5c4ba3707adb84416663634d4fc3141cbb/src/Worker.js#L80
+  const babelExtensions = DEFAULT_EXTENSIONS.map((ext) => ext.substring(1));
+  args.push(`--extensions=${[...babelExtensions, "ts", "tsx"].join(",")}`);
 }
 
 const disclaimerLines = [


### PR DESCRIPTION
### Issue

Fixes: https://github.com/aws/aws-sdk-js-codemod/issues/766

### Description

Explicitly pass all extensions by default when calling jscodeshift

### Testing

```console
$ export AWS_SDK_JS_CODEMOD_SUPRESS_WARNING=1
```

#### Before

The `ts` files were ignored if extension was not passed
```console
$ ./bin/aws-sdk-js-codemod -t v2-to-v3 ../test/test.ts 2>&1 | head -n 1
No files selected, nothing to do.
```

The extensions had to be explicitly set to `ts` for this to work
```console
$ ./bin/aws-sdk-js-codemod -t v2-to-v3 --extensions=ts ../test/test.ts 2>&1 | head -n 1
Processing 1 files...
```

#### After

The extensions option doesn't need to be explicitly set
```console
$ ./bin/aws-sdk-js-codemod -t v2-to-v3 ../test/test.ts 2>&1 | head -n 1
Processing 1 files...
```

The extensions option if explicitly passed, it's respected
```console
$ ./bin/aws-sdk-js-codemod -t v2-to-v3 --extensions=js ../test/test.ts 2>&1 | head -n 1
No files selected, nothing to do.

$ ./bin/aws-sdk-js-codemod -t v2-to-v3 --extensions=ts ../test/test.ts 2>&1 | head -n 1
Processing 1 files...
```

### Additional context

Bug reported upstream at https://github.com/facebook/jscodeshift/issues/582

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
