### PR TITLE
Process all extensions by default

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -24,7 +24,6 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 import path from "path";
-import { DEFAULT_EXTENSIONS } from "@babel/core";
 import Runner from "jscodeshift/dist/Runner";
 
 import {
@@ -39,16 +38,6 @@ const transforms = getTransforms();
 
 if (args[2] === "--help" || args[2] === "-h") {
   process.stdout.write(getHelpParagraph(transforms));
-}
-
-// Refs: https://github.com/facebook/jscodeshift/issues/582
-if (!args.some((arg) => arg.startsWith("--extensions"))) {
-  // Explicitly add all extensions as default to avoid bug in jscodeshift.
-  // Refs: https://github.com/facebook/jscodeshift/blob/51da1a5c4ba3707adb84416663634d4fc3141cbb/src/Worker.js#L80
-  const babelExtensions = DEFAULT_EXTENSIONS.map((ext) =>
-    ext.startsWith(".") ? ext.substring(1) : ext
-  );
-  args.push(`--extensions=${[...babelExtensions, "ts", "tsx"].join(",")}`);
 }
 
 const disclaimerLines = [

--- a/src/utils/getJsCodeshiftParser.ts
+++ b/src/utils/getJsCodeshiftParser.ts
@@ -76,7 +76,8 @@ export const getJsCodeshiftParser = () =>
     },
     extensions: {
       display_index: 3,
-      default: "js",
+      // Refs: https://github.com/facebook/jscodeshift/issues/582
+      // default: "js",
       help: "transform files with these file extensions (comma separated list)",
       metavar: "EXT",
     },


### PR DESCRIPTION
### Issue

Alternative to https://github.com/aws/aws-sdk-js-codemod/pull/767 which does not require reading extensions from `@babel/core`

### Description

What does this implement/fix? Explain your changes.

### Testing

How was this change tested?

### Additional context

Add any other context about the PR here.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
