### PR TITLE
Enable all supported extensions by default in config

### DIFF
--- a/.changeset/neat-peaches-call.md
+++ b/.changeset/neat-peaches-call.md
@@ -1,0 +1,5 @@
+---
+"aws-sdk-js-codemod": patch
+---
+
+Enable all supported extensions by default in config

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -24,7 +24,6 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 import path from "path";
-import { DEFAULT_EXTENSIONS } from "@babel/core";
 import Runner from "jscodeshift/dist/Runner";
 
 import {
@@ -39,16 +38,6 @@ const transforms = getTransforms();
 
 if (args[2] === "--help" || args[2] === "-h") {
   process.stdout.write(getHelpParagraph(transforms));
-}
-
-// Refs: https://github.com/facebook/jscodeshift/issues/582
-if (!args.some((arg) => arg.startsWith("--extensions"))) {
-  // Explicitly add all extensions as default to avoid bug in jscodeshift.
-  // Refs: https://github.com/facebook/jscodeshift/blob/51da1a5c4ba3707adb84416663634d4fc3141cbb/src/Worker.js#L80
-  const babelExtensions = DEFAULT_EXTENSIONS.map((ext) =>
-    ext.startsWith(".") ? ext.substring(1) : ext
-  );
-  args.push(`--extensions=${[...babelExtensions, "ts", "tsx"].join(",")}`);
 }
 
 const disclaimerLines = [

--- a/src/utils/getJsCodeshiftParser.ts
+++ b/src/utils/getJsCodeshiftParser.ts
@@ -6,6 +6,7 @@
 
 import { readFileSync } from "fs";
 import { dirname, join } from "path";
+import { DEFAULT_EXTENSIONS } from "@babel/core";
 import argsParser from "jscodeshift/dist/argsParser";
 
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -76,7 +77,14 @@ export const getJsCodeshiftParser = () =>
     },
     extensions: {
       display_index: 3,
-      default: "js",
+      // Explicitly add all extensions as default to avoid bug in jscodeshift.
+      // Refs: https://github.com/facebook/jscodeshift/issues/582
+      // Source code: https://github.com/facebook/jscodeshift/blob/51da1a5c4ba3707adb84416663634d4fc3141cbb/src/Worker.js#L80
+      default: [
+        ...DEFAULT_EXTENSIONS.map((ext) => (ext.startsWith(".") ? ext.substring(1) : ext)),
+        "ts",
+        "tsx",
+      ].join(","),
       help: "transform files with these file extensions (comma separated list)",
       metavar: "EXT",
     },

--- a/src/utils/getJsCodeshiftParser.ts
+++ b/src/utils/getJsCodeshiftParser.ts
@@ -84,7 +84,9 @@ export const getJsCodeshiftParser = () =>
         ...DEFAULT_EXTENSIONS.map((ext) => (ext.startsWith(".") ? ext.substring(1) : ext)),
         "ts",
         "tsx",
-      ].join(","),
+      ]
+        .sort()
+        .join(","),
       help: "transform files with these file extensions (comma separated list)",
       metavar: "EXT",
     },


### PR DESCRIPTION
### Issue

A cleaner alternative to https://github.com/aws/aws-sdk-js-codemod/pull/767

### Description

Enable all supported extensions by default in config

### Testing

```console
$ export AWS_SDK_JS_CODEMOD_SUPRESS_WARNING=1
```

The extensions option doesn't need to be explicitly set
```console
$ ./bin/aws-sdk-js-codemod -t v2-to-v3 ../test/test.ts 2>&1 | head -n 1
Processing 1 files...
```

The extensions option if explicitly passed, it's respected
```console
$ ./bin/aws-sdk-js-codemod -t v2-to-v3 --extensions=js ../test/test.ts 2>&1 | head -n 1
No files selected, nothing to do.

$ ./bin/aws-sdk-js-codemod -t v2-to-v3 --extensions=ts ../test/test.ts 2>&1 | head -n 1
Processing 1 files...
```

The default extensions are displayed in help
```console
$  ./bin/aws-sdk-js-codemod --help | grep -A 1 extensions
      --extensions=EXT          transform files with these file extensions (comma separated list)
                                (default: cjs,es,es6,js,jsx,mjs,ts,tsx)
```

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
