### PR TITLE
Bump actions checkout and setup-node to v4

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -11,8 +11,8 @@ jobs:
     needs: call-build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           cache: "yarn"
 


### PR DESCRIPTION
### Issue

Refs: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20

### Description

Bump actions checkout and setup-node to v4

### Testing

Will verify after push that warnings are not shown like one in previous runs
https://github.com/aws/aws-sdk-js-codemod/actions/runs/7982558050

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
