### PR TITLE
Bump jscodeshift to v0.15.2

### DIFF
--- a/.changeset/metal-peaches-film.md
+++ b/.changeset/metal-peaches-film.md
@@ -1,0 +1,5 @@
+---
+"aws-sdk-js-codemod": patch
+---
+
+Bump jscodeshift to v0.15.2

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "test": "vitest"
   },
   "dependencies": {
-    "jscodeshift": "0.15.1"
+    "jscodeshift": "0.15.2"
   },
   "devDependencies": {
     "@changesets/cli": "^2.27.1",

--- a/src/utils/getJsCodeshiftParser.ts
+++ b/src/utils/getJsCodeshiftParser.ts
@@ -27,6 +27,11 @@ const requirePackage = (name: string) => {
   return {};
 };
 
+const defaultExtensions = DEFAULT_EXTENSIONS.concat(["ts", "tsx"])
+  .map((ext) => (ext.startsWith(".") ? ext.substring(1) : ext))
+  .sort()
+  .join(",");
+
 /* eslint-disable @typescript-eslint/naming-convention */
 export const getJsCodeshiftParser = () =>
   argsParser.options({
@@ -77,16 +82,7 @@ export const getJsCodeshiftParser = () =>
     },
     extensions: {
       display_index: 3,
-      // Explicitly add all extensions as default to avoid bug in jscodeshift.
-      // Refs: https://github.com/facebook/jscodeshift/issues/582
-      // Source code: https://github.com/facebook/jscodeshift/blob/51da1a5c4ba3707adb84416663634d4fc3141cbb/src/Worker.js#L80
-      default: [
-        ...DEFAULT_EXTENSIONS.map((ext) => (ext.startsWith(".") ? ext.substring(1) : ext)),
-        "ts",
-        "tsx",
-      ]
-        .sort()
-        .join(","),
+      default: defaultExtensions,
       help: "transform files with these file extensions (comma separated list)",
       metavar: "EXT",
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1974,7 +1974,7 @@ __metadata:
     aws-sdk: "npm:2.1563.0"
     eslint: "npm:^8.56.0"
     eslint-plugin-import: "npm:^2.29.0"
-    jscodeshift: "npm:0.15.1"
+    jscodeshift: "npm:0.15.2"
     lint-staged: "npm:^13.0.3"
     prettier: "npm:3.0.3"
     simple-git-hooks: "npm:^2.8.1"
@@ -4133,9 +4133,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jscodeshift@npm:0.15.1":
-  version: 0.15.1
-  resolution: "jscodeshift@npm:0.15.1"
+"jscodeshift@npm:0.15.2":
+  version: 0.15.2
+  resolution: "jscodeshift@npm:0.15.2"
   dependencies:
     "@babel/core": "npm:^7.23.0"
     "@babel/parser": "npm:^7.23.0"
@@ -4164,7 +4164,7 @@ __metadata:
       optional: true
   bin:
     jscodeshift: bin/jscodeshift.js
-  checksum: 10c0/334de6ffa776a68b3f59f2f18a285ea977f3339d85e3517f3854761e65769ffa7e453c35cde320fc969106d573df39bd3fb08b23db54ae17c1b1516e5bf05742
+  checksum: 10c0/79afb059b9ca92712af02bdc8d6ff144de7aaf5e2cdcc6f6534e7a86a7347b0a278d9f4884f2c78dac424162a353aafff183a60e868f71132be2c5b5304aeeb8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Issue

https://github.com/facebook/jscodeshift/releases/tag/v0.15.2

### Description

Bumps jscodeshift to v0.15.2

### Testing

```console
$ export AWS_SDK_JS_CODEMOD_SUPRESS_WARNING=1
```

The extensions option doesn't need to be explicitly set
```console
$ ./bin/aws-sdk-js-codemod -t v2-to-v3 ../test/test.ts 2>&1 | head -n 1
Processing 1 files...
```

The extensions option if explicitly passed, it's respected
```console
$ ./bin/aws-sdk-js-codemod -t v2-to-v3 --extensions=js ../test/test.ts 2>&1 | head -n 1
No files selected, nothing to do.

$ ./bin/aws-sdk-js-codemod -t v2-to-v3 --extensions=ts ../test/test.ts 2>&1 | head -n 1
Processing 1 files...
```

The default extensions are displayed in help
```console
$  ./bin/aws-sdk-js-codemod --help | grep -A 1 extensions
      --extensions=EXT          transform files with these file extensions (comma separated list)
                                (default: cjs,es,es6,js,jsx,mjs,ts,tsx)
```

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
