### PR TITLE
Skip transformation if "aws-sdk" import is not present

### DIFF
--- a/.changeset/silly-coats-worry.md
+++ b/.changeset/silly-coats-worry.md
@@ -1,0 +1,5 @@
+---
+"aws-sdk-js-codemod": patch
+---
+
+Skip transformation if "aws-sdk" import is not present

--- a/src/transforms/v2-to-v3/modules/getImportType.ts
+++ b/src/transforms/v2-to-v3/modules/getImportType.ts
@@ -1,6 +1,7 @@
 import { Collection, JSCodeshift } from "jscodeshift";
 import { hasImport } from "./hasImport";
 import { hasImportEquals } from "./hasImportEquals";
+import { hasRequire } from "./hasRequire";
 import { ImportType } from "./types";
 
 export const getImportType = (j: JSCodeshift, source: Collection<unknown>) =>
@@ -8,4 +9,6 @@ export const getImportType = (j: JSCodeshift, source: Collection<unknown>) =>
     ? ImportType.IMPORT
     : hasImportEquals(j, source)
     ? ImportType.IMPORT_EQUALS
-    : ImportType.REQUIRE;
+    : hasRequire(j, source)
+    ? ImportType.REQUIRE
+    : null;

--- a/src/transforms/v2-to-v3/modules/hasImportEquals.ts
+++ b/src/transforms/v2-to-v3/modules/hasImportEquals.ts
@@ -1,5 +1,6 @@
 import { Collection, JSCodeshift } from "jscodeshift";
 
+import { PACKAGE_NAME } from "../config";
 import { getImportEqualsDeclarationType } from "./getImportEqualsDeclarationType";
 
 export const hasImportEquals = (j: JSCodeshift, source: Collection<unknown>) =>
@@ -12,7 +13,7 @@ export const hasImportEquals = (j: JSCodeshift, source: Collection<unknown>) =>
       return (
         expression.type === "StringLiteral" &&
         typeof expression.value === "string" &&
-        expression.value.startsWith("aws-sdk")
+        expression.value.startsWith(PACKAGE_NAME)
       );
     })
     .size() > 0;

--- a/src/transforms/v2-to-v3/modules/hasRequire.ts
+++ b/src/transforms/v2-to-v3/modules/hasRequire.ts
@@ -1,0 +1,13 @@
+import { Collection, JSCodeshift, Literal } from "jscodeshift";
+import { PACKAGE_NAME } from "../config";
+
+export const hasRequire = (j: JSCodeshift, source: Collection<unknown>) =>
+  source
+    .find(j.CallExpression, {
+      callee: { type: "Identifier", name: "require" },
+    })
+    .filter((callExpression) => {
+      const { value: sourceValue } = callExpression.value.arguments[0] as Literal;
+      return typeof sourceValue === "string" && sourceValue.startsWith(PACKAGE_NAME);
+    })
+    .size() > 0;

--- a/src/transforms/v2-to-v3/transformer.ts
+++ b/src/transforms/v2-to-v3/transformer.ts
@@ -47,6 +47,7 @@ const transformer = async (file: FileInfo, api: API) => {
   const importType = getImportType(j, source);
 
   if (importType === null) {
+    // Skip transformation, since no import/require statements found for "aws-sdk" package.
     return file.source;
   }
 

--- a/src/transforms/v2-to-v3/transformer.ts
+++ b/src/transforms/v2-to-v3/transformer.ts
@@ -46,14 +46,14 @@ const transformer = async (file: FileInfo, api: API) => {
   const source = j(file.source);
   const importType = getImportType(j, source);
 
+  if (importType === null) {
+    return file.source;
+  }
+
   addNotSupportedComments(j, source, importType);
 
   const v2GlobalName = getGlobalNameFromModule(j, source);
   const v2ClientNamesRecord = getClientNamesRecord(j, source, importType);
-
-  if (!v2GlobalName && Object.keys(v2ClientNamesRecord).length === 0) {
-    return file.source;
-  }
 
   if (v2GlobalName) {
     for (const v2ClientNameFromGlobal of getClientNamesFromGlobal(j, source, v2GlobalName)) {


### PR DESCRIPTION
### Issue

Right now, the transformation is skipped if either the global import is not present, or clients are not created from package import

https://github.com/aws/aws-sdk-js-codemod/blob/36c992b549bbde9ecf46086fb5d19ba363bc7239/src/transforms/v2-to-v3/transformer.ts#L54-L56

This is a blocker for implementing named imports of non-clients, like Credentials https://github.com/aws/aws-sdk-js-codemod/issues/777

### Description

Skip transformation only if "aws-sdk" import is not present

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
