### PR TITLE
Make importedName optional in ImportSpecifierType

### DIFF
--- a/.changeset/proud-kings-exercise.md
+++ b/.changeset/proud-kings-exercise.md
@@ -1,0 +1,5 @@
+---
+"aws-sdk-js-codemod": patch
+---
+
+Make importedName optional in ImportSpecifierType

--- a/src/transforms/v2-to-v3/apis/replaceAwsIdentity.ts
+++ b/src/transforms/v2-to-v3/apis/replaceAwsIdentity.ts
@@ -69,7 +69,7 @@ export const replaceAwsIdentity = (
       if (credsNewExpressions.size() > 0) {
         addNamedModule(j, source, {
           importType,
-          importedName: v3ProviderName,
+          localName: v3ProviderName,
           packageName: identityPackageName,
         });
         credsNewExpressions.replaceWith(({ node }) =>

--- a/src/transforms/v2-to-v3/client-names/getClientNamesRecordFromImport.ts
+++ b/src/transforms/v2-to-v3/client-names/getClientNamesRecordFromImport.ts
@@ -21,8 +21,9 @@ export const getClientNamesRecordFromImport = (
   ) as ImportSpecifierPattern[];
 
   for (const { importedName, localName } of specifiersFromNamedImport) {
-    if (CLIENT_NAMES.includes(localName)) {
-      clientNamesRecord[localName] = importedName ?? localName;
+    const clientName = importedName ?? localName;
+    if (CLIENT_NAMES.includes(clientName)) {
+      clientNamesRecord[clientName] = localName;
     }
   }
 

--- a/src/transforms/v2-to-v3/client-names/getClientNamesRecordFromImport.ts
+++ b/src/transforms/v2-to-v3/client-names/getClientNamesRecordFromImport.ts
@@ -21,8 +21,8 @@ export const getClientNamesRecordFromImport = (
   ) as ImportSpecifierPattern[];
 
   for (const { importedName, localName } of specifiersFromNamedImport) {
-    if (CLIENT_NAMES.includes(importedName)) {
-      clientNamesRecord[importedName] = localName ?? importedName;
+    if (CLIENT_NAMES.includes(localName)) {
+      clientNamesRecord[localName] = importedName ?? localName;
     }
   }
 

--- a/src/transforms/v2-to-v3/client-names/getClientNamesRecordFromImport.ts
+++ b/src/transforms/v2-to-v3/client-names/getClientNamesRecordFromImport.ts
@@ -1,11 +1,7 @@
 import { Collection, JSCodeshift } from "jscodeshift";
 
 import { CLIENT_NAMES, PACKAGE_NAME } from "../config";
-import {
-  ImportSpecifierDefault,
-  ImportSpecifierPattern,
-  getImportEqualsDeclarationType,
-} from "../modules";
+import { getImportEqualsDeclarationType } from "../modules";
 import { getImportSpecifiers } from "../modules/importModule";
 import { getClientDeepImportPath } from "../utils";
 
@@ -17,8 +13,8 @@ export const getClientNamesRecordFromImport = (
   const clientNamesRecord: Record<string, string> = {};
 
   const specifiersFromNamedImport = getImportSpecifiers(j, source, PACKAGE_NAME).filter(
-    (importSpecifier) => typeof importSpecifier === "object"
-  ) as ImportSpecifierPattern[];
+    (importSpecifier) => importSpecifier.importedName
+  );
 
   for (const { importedName, localName } of specifiersFromNamedImport) {
     const clientName = importedName ?? localName;
@@ -31,10 +27,10 @@ export const getClientNamesRecordFromImport = (
     const deepImportPath = getClientDeepImportPath(clientName);
 
     const specifiersFromDeepImport = getImportSpecifiers(j, source, deepImportPath).filter(
-      (importSpecifier) => typeof importSpecifier === "string"
-    ) as ImportSpecifierDefault[];
+      (importSpecifier) => !importSpecifier.importedName
+    );
     if (specifiersFromDeepImport.length > 0) {
-      clientNamesRecord[clientName] = specifiersFromDeepImport[0];
+      clientNamesRecord[clientName] = specifiersFromDeepImport[0].localName;
     }
 
     const identifiersFromImportEquals = source.find(

--- a/src/transforms/v2-to-v3/client-names/getClientNamesRecordFromRequire.ts
+++ b/src/transforms/v2-to-v3/client-names/getClientNamesRecordFromRequire.ts
@@ -1,7 +1,6 @@
 import { Collection, JSCodeshift } from "jscodeshift";
 
 import { CLIENT_NAMES, PACKAGE_NAME } from "../config";
-import { ImportSpecifierDefault, ImportSpecifierPattern } from "../modules";
 import { getImportSpecifiers } from "../modules/requireModule";
 import { getClientDeepImportPath } from "../utils";
 
@@ -13,8 +12,8 @@ export const getClientNamesRecordFromRequire = (
   const clientNamesRecord: Record<string, string> = {};
 
   const idPropertiesFromObjectPattern = getImportSpecifiers(j, source, PACKAGE_NAME).filter(
-    (importSpecifier) => typeof importSpecifier === "object"
-  ) as ImportSpecifierPattern[];
+    (importSpecifier) => importSpecifier.importedName
+  );
 
   for (const { importedName, localName } of idPropertiesFromObjectPattern) {
     const clientName = importedName ?? localName;
@@ -26,10 +25,10 @@ export const getClientNamesRecordFromRequire = (
   for (const clientName of clientNamesFromDeepImport) {
     const deepImportPath = getClientDeepImportPath(clientName);
     const idsFromDefaultImport = getImportSpecifiers(j, source, deepImportPath).filter(
-      (importSpecifier) => typeof importSpecifier === "string"
-    ) as ImportSpecifierDefault[];
+      (importSpecifier) => !importSpecifier.importedName
+    );
     if (idsFromDefaultImport.length) {
-      clientNamesRecord[clientName] = idsFromDefaultImport[0];
+      clientNamesRecord[clientName] = idsFromDefaultImport[0].localName;
     }
   }
 

--- a/src/transforms/v2-to-v3/client-names/getClientNamesRecordFromRequire.ts
+++ b/src/transforms/v2-to-v3/client-names/getClientNamesRecordFromRequire.ts
@@ -17,8 +17,8 @@ export const getClientNamesRecordFromRequire = (
   ) as ImportSpecifierPattern[];
 
   for (const { importedName, localName } of idPropertiesFromObjectPattern) {
-    if (CLIENT_NAMES.includes(importedName)) {
-      clientNamesRecord[importedName] = localName || importedName;
+    if (CLIENT_NAMES.includes(localName)) {
+      clientNamesRecord[localName] = importedName ?? localName;
     }
   }
 

--- a/src/transforms/v2-to-v3/client-names/getClientNamesRecordFromRequire.ts
+++ b/src/transforms/v2-to-v3/client-names/getClientNamesRecordFromRequire.ts
@@ -17,8 +17,9 @@ export const getClientNamesRecordFromRequire = (
   ) as ImportSpecifierPattern[];
 
   for (const { importedName, localName } of idPropertiesFromObjectPattern) {
-    if (CLIENT_NAMES.includes(localName)) {
-      clientNamesRecord[localName] = importedName ?? localName;
+    const clientName = importedName ?? localName;
+    if (CLIENT_NAMES.includes(clientName)) {
+      clientNamesRecord[clientName] = localName;
     }
   }
 

--- a/src/transforms/v2-to-v3/modules/addClientModules.ts
+++ b/src/transforms/v2-to-v3/modules/addClientModules.ts
@@ -45,7 +45,7 @@ export const addClientModules = (
   for (const v3ClientType of v3ClientTypes) {
     addNamedModule(j, source, {
       importType,
-      importedName: v3ClientType,
+      localName: v3ClientType,
       packageName: v3ClientPackageName,
     });
   }
@@ -63,7 +63,7 @@ export const addClientModules = (
     const v3WaiterApiName = getV3ClientWaiterApiName(waiterState);
     addNamedModule(j, source, {
       importType,
-      importedName: v3WaiterApiName,
+      localName: v3WaiterApiName,
       packageName: v3ClientPackageName,
     });
   }
@@ -72,7 +72,7 @@ export const addClientModules = (
     if (isS3UploadApiUsed(j, source, clientIdentifiers)) {
       addNamedModule(j, source, {
         importType,
-        importedName: "Upload",
+        localName: "Upload",
         packageName: "@aws-sdk/lib-storage",
       });
     }
@@ -80,13 +80,13 @@ export const addClientModules = (
     if (isS3GetSignedUrlApiUsed(j, source, clientIdentifiers)) {
       addNamedModule(j, source, {
         importType,
-        importedName: "getSignedUrl",
+        localName: "getSignedUrl",
         packageName: "@aws-sdk/s3-request-presigner",
       });
       for (const apiName of getS3SignedUrlApiNames(j, source, clientIdentifiers)) {
         addNamedModule(j, source, {
           importType,
-          importedName: getCommandName(apiName),
+          localName: getCommandName(apiName),
           packageName: v3ClientPackageName,
         });
       }
@@ -111,7 +111,7 @@ export const addClientModules = (
     for (const docClientType of docClientTypes) {
       addNamedModule(j, source, {
         importType,
-        importedName: docClientType,
+        localName: docClientType,
         packageName: "@aws-sdk/lib-dynamodb",
       });
     }
@@ -119,7 +119,7 @@ export const addClientModules = (
     if (docClientNewExpressionCount > 0) {
       addNamedModule(j, source, {
         importType,
-        importedName: DYNAMODB_DOCUMENT,
+        localName: DYNAMODB_DOCUMENT,
         packageName: "@aws-sdk/lib-dynamodb",
       });
     }

--- a/src/transforms/v2-to-v3/modules/getGlobalNameFromModule.ts
+++ b/src/transforms/v2-to-v3/modules/getGlobalNameFromModule.ts
@@ -4,7 +4,6 @@ import { PACKAGE_NAME } from "../config";
 import { getImportEqualsDeclarationType } from "./getImportEqualsDeclarationType";
 import { getImportSpecifiers } from "./importModule";
 import { getRequireDeclarators } from "./requireModule";
-import { ImportSpecifierDefault } from ".";
 
 export const getGlobalNameFromModule = (
   j: JSCodeshift,
@@ -19,11 +18,11 @@ export const getGlobalNameFromModule = (
   }
 
   const importDefaultSpecifiers = getImportSpecifiers(j, source, PACKAGE_NAME).filter(
-    (importSpecifier) => typeof importSpecifier === "string"
-  ) as ImportSpecifierDefault[];
+    (importSpecifier) => !importSpecifier.importedName
+  );
 
   if (importDefaultSpecifiers.length > 0) {
-    return importDefaultSpecifiers[0];
+    return importDefaultSpecifiers[0].localName;
   }
 
   const importEqualsDeclarations = source.find(

--- a/src/transforms/v2-to-v3/modules/importEqualsModule/addNamedModule.ts
+++ b/src/transforms/v2-to-v3/modules/importEqualsModule/addNamedModule.ts
@@ -10,7 +10,7 @@ export const addNamedModule = (
   source: Collection<unknown>,
   options: ModulesOptions
 ) => {
-  const { importedName, localName = importedName, packageName } = options;
+  const { localName, importedName = localName, packageName } = options;
 
   const defaultLocalName = getDefaultName(packageName);
 

--- a/src/transforms/v2-to-v3/modules/importModule/addNamedModule.ts
+++ b/src/transforms/v2-to-v3/modules/importModule/addNamedModule.ts
@@ -9,7 +9,7 @@ export const addNamedModule = (
   source: Collection<unknown>,
   options: ModulesOptions
 ) => {
-  const { importedName, localName = importedName, packageName } = options;
+  const { localName, importedName = localName, packageName } = options;
 
   const importSpecifiers = getImportSpecifiers(j, source, packageName);
 

--- a/src/transforms/v2-to-v3/modules/importModule/getImportSpecifiers.ts
+++ b/src/transforms/v2-to-v3/modules/importModule/getImportSpecifiers.ts
@@ -24,7 +24,7 @@ export const getImportSpecifiers = (
         case "ImportNamespaceSpecifier":
         case "ImportDefaultSpecifier": {
           if (specifier.local) {
-            importSpecifiers.add(specifier.local.name);
+            importSpecifiers.add({ localName: specifier.local.name });
           }
           break;
         }

--- a/src/transforms/v2-to-v3/modules/requireModule/addNamedModule.ts
+++ b/src/transforms/v2-to-v3/modules/requireModule/addNamedModule.ts
@@ -18,11 +18,11 @@ export const addNamedModule = (
   source: Collection<unknown>,
   options: ModulesOptions
 ) => {
-  const { importedName, localName = importedName, packageName } = options;
+  const { localName, importedName = localName, packageName } = options;
 
   const clientObjectProperty = j.objectProperty.from({
     key: j.identifier(importedName),
-    value: j.identifier(localName ?? importedName),
+    value: j.identifier(localName),
     shorthand: true,
   });
   const existingRequires = getRequireDeclarators(j, source, packageName);

--- a/src/transforms/v2-to-v3/modules/requireModule/getImportSpecifiers.ts
+++ b/src/transforms/v2-to-v3/modules/requireModule/getImportSpecifiers.ts
@@ -1,10 +1,10 @@
 import { Collection, Identifier, JSCodeshift, ObjectProperty, Property } from "jscodeshift";
 import { OBJECT_PROPERTY_TYPE_LIST } from "../../config";
-import { ImportSpecifierPattern, ImportSpecifierType } from "../types";
+import { ImportSpecifierType } from "../types";
 import { getRequireDeclarators } from "./getRequireDeclarators";
 
 const getImportSpecifiersFromObjectPattern = (properties: (Property | ObjectProperty)[]) => {
-  const importSpecifiers = new Set<ImportSpecifierPattern>();
+  const importSpecifiers = new Set<ImportSpecifierType>();
 
   for (const property of properties) {
     if (!OBJECT_PROPERTY_TYPE_LIST.includes(property.type)) {
@@ -43,7 +43,7 @@ export const getImportSpecifiers = (
           localName: declaratorIdName,
         });
       } else {
-        importSpecifiers.add(declaratorIdName);
+        importSpecifiers.add({ localName: declaratorIdName });
       }
     }
 

--- a/src/transforms/v2-to-v3/modules/types.ts
+++ b/src/transforms/v2-to-v3/modules/types.ts
@@ -11,8 +11,8 @@ export interface ClientModulesOptions {
 }
 
 export interface ImportSpecifierPattern {
-  importedName: string;
-  localName?: string;
+  importedName?: string;
+  localName: string;
 }
 
 export type ImportSpecifierDefault = string;

--- a/src/transforms/v2-to-v3/modules/types.ts
+++ b/src/transforms/v2-to-v3/modules/types.ts
@@ -10,16 +10,12 @@ export interface ClientModulesOptions {
   importType: ImportType;
 }
 
-export interface ImportSpecifierPattern {
+export interface ImportSpecifierType {
   importedName?: string;
   localName: string;
 }
 
-export type ImportSpecifierDefault = string;
-
-export type ImportSpecifierType = ImportSpecifierPattern | ImportSpecifierDefault;
-
-export interface ModulesOptions extends ImportSpecifierPattern {
+export interface ModulesOptions extends ImportSpecifierType {
   packageName: string;
 }
 

--- a/src/transforms/v2-to-v3/ts-type/getClientTypeNames.ts
+++ b/src/transforms/v2-to-v3/ts-type/getClientTypeNames.ts
@@ -1,6 +1,6 @@
 import { Collection, Identifier, JSCodeshift, TSQualifiedName, TSTypeReference } from "jscodeshift";
 
-import { ImportSpecifierPattern } from "../modules";
+import { ImportSpecifierType } from "../modules";
 import { getImportSpecifiers } from "../modules/importModule";
 import { getClientDeepImportPath } from "../utils";
 
@@ -77,8 +77,8 @@ export const getClientTypeNames = (
 
   clientTypeNames.push(
     ...getImportSpecifiers(j, source, getClientDeepImportPath(v2ClientName))
-      .filter((importSpecifier) => typeof importSpecifier === "object")
-      .map((importSpecifier) => (importSpecifier as ImportSpecifierPattern).localName!)
+      .filter((importSpecifier) => importSpecifier.importedName)
+      .map((importSpecifier) => (importSpecifier as ImportSpecifierType).localName!)
   );
 
   return [...new Set(clientTypeNames)];


### PR DESCRIPTION
### Issue

The localname is always present in ImportSpecifier, i.e. ImportDefaultSpecifier or ImportNamespaceSpecifier.

```js
import AWS from "aws-sdk";
import * as AWS from "aws-sdk";
```

The imported name is present only in ImportSpecifier, and it's different from local name
```js
import { DynamoDB as DynDB } from "aws-sdk";
```

Making this change in our custom types.

### Description

Make importedName optional in ImportSpecifierType

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
