### PR TITLE
chore(deps-dev): bump prettier to 3.2.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "scripts": {
     "build": "tsc",
     "lint": "eslint 'src/**/*.ts'",
+    "prepare": "simple-git-hooks",
     "release": "yarn build && changeset publish",
     "test": "vitest"
   },
@@ -52,7 +53,7 @@
     "eslint": "^8.57.0",
     "eslint-plugin-import": "^2.29.1",
     "lint-staged": "^15.2.2",
-    "prettier": "3.0.3",
+    "prettier": "3.2.5",
     "simple-git-hooks": "^2.11.0",
     "tsx": "^4.7.1",
     "typescript": "~5.4.2",

--- a/simple-git-hooks.json
+++ b/simple-git-hooks.json
@@ -1,3 +1,3 @@
 {
-  "pre-commit": "npx lint-staged"
+  "pre-commit": "yarn lint-staged"
 }

--- a/src/transforms/v2-to-v3/client-names/getClientNamesRecord.ts
+++ b/src/transforms/v2-to-v3/client-names/getClientNamesRecord.ts
@@ -19,8 +19,8 @@ export const getClientNamesRecord = (
     importType === ImportType.REQUIRE
       ? requireModule
       : importType === ImportType.IMPORT_EQUALS
-      ? importEqualsModule
-      : importModule;
+        ? importEqualsModule
+        : importModule;
 
   const specifiersFromNamedImport = getImportSpecifiers(j, source, PACKAGE_NAME).filter(
     (importSpecifier) => importSpecifier.importedName

--- a/src/transforms/v2-to-v3/modules/addNamedModule.ts
+++ b/src/transforms/v2-to-v3/modules/addNamedModule.ts
@@ -16,8 +16,8 @@ export const addNamedModule = (
     importType === ImportType.REQUIRE
       ? requireModule
       : importType === ImportType.IMPORT_EQUALS
-      ? importEqualsModule
-      : importModule;
+        ? importEqualsModule
+        : importModule;
 
   addNamedModule(j, source, addNamedModuleOptions);
 };

--- a/src/transforms/v2-to-v3/modules/getImportType.ts
+++ b/src/transforms/v2-to-v3/modules/getImportType.ts
@@ -8,7 +8,7 @@ export const getImportType = (j: JSCodeshift, source: Collection<unknown>) =>
   hasImport(j, source)
     ? ImportType.IMPORT
     : hasImportEquals(j, source)
-    ? ImportType.IMPORT_EQUALS
-    : hasRequire(j, source)
-    ? ImportType.REQUIRE
-    : null;
+      ? ImportType.IMPORT_EQUALS
+      : hasRequire(j, source)
+        ? ImportType.REQUIRE
+        : null;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1788,7 +1788,7 @@ __metadata:
     eslint-plugin-import: "npm:^2.29.1"
     jscodeshift: "npm:0.15.2"
     lint-staged: "npm:^15.2.2"
-    prettier: "npm:3.0.3"
+    prettier: "npm:3.2.5"
     simple-git-hooks: "npm:^2.11.0"
     tsx: "npm:^4.7.1"
     typescript: "npm:~5.4.2"
@@ -4996,12 +4996,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prettier@npm:3.0.3":
-  version: 3.0.3
-  resolution: "prettier@npm:3.0.3"
+"prettier@npm:3.2.5":
+  version: 3.2.5
+  resolution: "prettier@npm:3.2.5"
   bin:
     prettier: bin/prettier.cjs
-  checksum: 10c0/f950887bc03c5b970d8c6dd129364acfbbc61e7b46aec5d5ce17f4adf6404e2ef43072c98b51c4786e0eaca949b307d362a773fd47502862d754b5a328fa2b26
+  checksum: 10c0/ea327f37a7d46f2324a34ad35292af2ad4c4c3c3355da07313339d7e554320f66f65f91e856add8530157a733c6c4a897dc41b577056be5c24c40f739f5ee8c6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Issue

Routine upgrade before 4.0

### Description

Bumps prettier to 3.2.5

### Testing

Precommit is successful
```console
$ git commit -m "chore(deps-dev): bump prettier to 3.2.5"
✔ Preparing lint-staged...
✔ Running tasks for staged files...
✔ Applying modifications from tasks...
✔ Cleaning up temporary files...
[bump-prettier d902aea] chore(deps-dev): bump prettier to 3.2.5
 Date: Mon Mar 18 14:26:52 2024 -0700
 3 files changed, 8 insertions(+), 7 deletions(-)
```

Prettier all source files:
```console
$ yarn prettier --write **/*.ts

$ yarn prettier --write *.{json,md}
```

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
