### PR TITLE
Transform checks for error.code to error.name in promise catch

### DIFF
--- a/.changeset/lemon-days-dress.md
+++ b/.changeset/lemon-days-dress.md
@@ -1,0 +1,5 @@
+---
+"aws-sdk-js-codemod": patch
+---
+
+Transform checks for error.code to error.name in promise catch

--- a/src/transforms/v2-to-v3/__fixtures__/aws-error-name/global-import.input.js
+++ b/src/transforms/v2-to-v3/__fixtures__/aws-error-name/global-import.input.js
@@ -1,11 +1,10 @@
 import AWS from "aws-sdk";
 
 const client = new AWS.S3();
+const Bucket = "bucket-name";
 
 try {
-  await client.createBucket({
-    Bucket: "bucket"
-  }).promise();
+  await client.createBucket({ Bucket }).promise();
 } catch (error) {
   if (error.code === "BucketAlreadyExists") {
     // Handle BucketAlreadyExists error
@@ -13,3 +12,17 @@ try {
     throw error;
   }
 }
+
+client
+  .createBucket({ Bucket })
+  .promise()
+  .then((response) => {
+    // Consume the response
+  })
+  .catch((error) => {
+    if (error.code === "BucketAlreadyExists") {
+      // Handle BucketAlreadyExists error
+    } else {
+      // Handle other error.
+    }
+  });

--- a/src/transforms/v2-to-v3/__fixtures__/aws-error-name/global-import.input.js
+++ b/src/transforms/v2-to-v3/__fixtures__/aws-error-name/global-import.input.js
@@ -26,3 +26,17 @@ client
       // Handle other error.
     }
   });
+
+client
+  .createBucket({ Bucket })
+  .promise()
+  .then((response) => {
+    // Consume the response
+  })
+  .catch(function (error) {
+    if (error.code === "BucketAlreadyExists") {
+      // Handle BucketAlreadyExists error
+    } else {
+      // Handle other error.
+    }
+  });

--- a/src/transforms/v2-to-v3/__fixtures__/aws-error-name/global-import.input.ts
+++ b/src/transforms/v2-to-v3/__fixtures__/aws-error-name/global-import.input.ts
@@ -1,10 +1,10 @@
 import AWS from "aws-sdk";
 
-export const func = async (client: AWS.S3) => {
+const Bucket = "bucket-name";
+
+export const funcTryCatch = async (client: AWS.S3) => {
   try {
-    await client.createBucket({
-      Bucket: "bucket"
-    }).promise();
+    await client.createBucket({ Bucket }).promise();
   } catch (error) {
     if (error.code === "BucketAlreadyExists") {
       // Handle BucketAlreadyExists error
@@ -12,4 +12,36 @@ export const func = async (client: AWS.S3) => {
       throw error;
     }
   }
+}
+
+export const funcPromiseCatchArrowFn = async (client: AWS.S3) => {
+  client
+    .createBucket({ Bucket })
+    .promise()
+    .then((response) => {
+      // Consume the response
+    })
+    .catch((error) => {
+      if (error.code === "BucketAlreadyExists") {
+        // Handle BucketAlreadyExists error
+      } else {
+        // Handle other error.
+      }
+    });
+}
+
+export const funcPromiseCatchFn = async (client: AWS.S3) => {
+  client
+    .createBucket({ Bucket })
+    .promise()
+    .then((response) => {
+      // Consume the response
+    })
+    .catch(function (error) {
+      if (error.code === "BucketAlreadyExists") {
+        // Handle BucketAlreadyExists error
+      } else {
+        // Handle other error.
+      }
+    });
 }

--- a/src/transforms/v2-to-v3/__fixtures__/aws-error-name/global-import.output.js
+++ b/src/transforms/v2-to-v3/__fixtures__/aws-error-name/global-import.output.js
@@ -1,11 +1,10 @@
 import { S3 } from "@aws-sdk/client-s3";
 
 const client = new S3();
+const Bucket = "bucket-name";
 
 try {
-  await client.createBucket({
-    Bucket: "bucket"
-  });
+  await client.createBucket({ Bucket });
 } catch (error) {
   if (error.name === "BucketAlreadyExists") {
     // Handle BucketAlreadyExists error
@@ -13,3 +12,16 @@ try {
     throw error;
   }
 }
+
+client
+  .createBucket({ Bucket })
+  .then((response) => {
+    // Consume the response
+  })
+  .catch((error) => {
+    if (error.name === "BucketAlreadyExists") {
+      // Handle BucketAlreadyExists error
+    } else {
+      // Handle other error.
+    }
+  });

--- a/src/transforms/v2-to-v3/__fixtures__/aws-error-name/global-import.output.js
+++ b/src/transforms/v2-to-v3/__fixtures__/aws-error-name/global-import.output.js
@@ -25,3 +25,16 @@ client
       // Handle other error.
     }
   });
+
+client
+  .createBucket({ Bucket })
+  .then((response) => {
+    // Consume the response
+  })
+  .catch(function (error) {
+    if (error.name === "BucketAlreadyExists") {
+      // Handle BucketAlreadyExists error
+    } else {
+      // Handle other error.
+    }
+  });

--- a/src/transforms/v2-to-v3/__fixtures__/aws-error-name/global-import.output.ts
+++ b/src/transforms/v2-to-v3/__fixtures__/aws-error-name/global-import.output.ts
@@ -1,10 +1,10 @@
 import { S3 } from "@aws-sdk/client-s3";
 
-export const func = async (client: S3) => {
+const Bucket = "bucket-name";
+
+export const funcTryCatch = async (client: S3) => {
   try {
-    await client.createBucket({
-      Bucket: "bucket"
-    });
+    await client.createBucket({ Bucket });
   } catch (error) {
     if (error.name === "BucketAlreadyExists") {
       // Handle BucketAlreadyExists error
@@ -12,4 +12,34 @@ export const func = async (client: S3) => {
       throw error;
     }
   }
+}
+
+export const funcPromiseCatchArrowFn = async (client: S3) => {
+  client
+    .createBucket({ Bucket })
+    .then((response) => {
+      // Consume the response
+    })
+    .catch((error) => {
+      if (error.name === "BucketAlreadyExists") {
+        // Handle BucketAlreadyExists error
+      } else {
+        // Handle other error.
+      }
+    });
+}
+
+export const funcPromiseCatchFn = async (client: S3) => {
+  client
+    .createBucket({ Bucket })
+    .then((response) => {
+      // Consume the response
+    })
+    .catch(function (error) {
+      if (error.name === "BucketAlreadyExists") {
+        // Handle BucketAlreadyExists error
+      } else {
+        // Handle other error.
+      }
+    });
 }

--- a/src/transforms/v2-to-v3/__fixtures__/aws-error-name/service-import.input.js
+++ b/src/transforms/v2-to-v3/__fixtures__/aws-error-name/service-import.input.js
@@ -1,11 +1,10 @@
 import { S3 } from "aws-sdk";
 
 const client = new S3();
+const Bucket = "bucket-name";
 
 try {
-  await client.createBucket({
-    Bucket: "bucket"
-  }).promise();
+  await client.createBucket({ Bucket }).promise();
 } catch (error) {
   if (error.code === "BucketAlreadyExists") {
     // Handle BucketAlreadyExists error
@@ -13,3 +12,31 @@ try {
     throw error;
   }
 }
+
+client
+  .createBucket({ Bucket })
+  .promise()
+  .then((response) => {
+    // Consume the response
+  })
+  .catch((error) => {
+    if (error.code === "BucketAlreadyExists") {
+      // Handle BucketAlreadyExists error
+    } else {
+      // Handle other error.
+    }
+  });
+
+client
+  .createBucket({ Bucket })
+  .promise()
+  .then((response) => {
+    // Consume the response
+  })
+  .catch(function (error) {
+    if (error.code === "BucketAlreadyExists") {
+      // Handle BucketAlreadyExists error
+    } else {
+      // Handle other error.
+    }
+  });

--- a/src/transforms/v2-to-v3/__fixtures__/aws-error-name/service-import.input.ts
+++ b/src/transforms/v2-to-v3/__fixtures__/aws-error-name/service-import.input.ts
@@ -1,10 +1,10 @@
 import { S3 } from "aws-sdk";
 
+const Bucket = "bucket-name";
+
 export const func = async (client: S3) => {
   try {
-    await client.createBucket({
-      Bucket: "bucket"
-    }).promise();
+    await client.createBucket({ Bucket }).promise();
   } catch (error) {
     if (error.code === "BucketAlreadyExists") {
       // Handle BucketAlreadyExists error
@@ -12,4 +12,36 @@ export const func = async (client: S3) => {
       throw error;
     }
   }
+}
+
+export const funcPromiseCatchArrowFn = async (client: S3) => {
+  client
+    .createBucket({ Bucket })
+    .promise()
+    .then((response) => {
+      // Consume the response
+    })
+    .catch((error) => {
+      if (error.code === "BucketAlreadyExists") {
+        // Handle BucketAlreadyExists error
+      } else {
+        // Handle other error.
+      }
+    });
+}
+
+export const funcPromiseCatchFn = async (client: S3) => {
+  client
+    .createBucket({ Bucket })
+    .promise()
+    .then((response) => {
+      // Consume the response
+    })
+    .catch(function (error) {
+      if (error.code === "BucketAlreadyExists") {
+        // Handle BucketAlreadyExists error
+      } else {
+        // Handle other error.
+      }
+    });
 }

--- a/src/transforms/v2-to-v3/__fixtures__/aws-error-name/service-import.output.js
+++ b/src/transforms/v2-to-v3/__fixtures__/aws-error-name/service-import.output.js
@@ -1,11 +1,10 @@
 import { S3 } from "@aws-sdk/client-s3";
 
 const client = new S3();
+const Bucket = "bucket-name";
 
 try {
-  await client.createBucket({
-    Bucket: "bucket"
-  });
+  await client.createBucket({ Bucket });
 } catch (error) {
   if (error.name === "BucketAlreadyExists") {
     // Handle BucketAlreadyExists error
@@ -13,3 +12,29 @@ try {
     throw error;
   }
 }
+
+client
+  .createBucket({ Bucket })
+  .then((response) => {
+    // Consume the response
+  })
+  .catch((error) => {
+    if (error.name === "BucketAlreadyExists") {
+      // Handle BucketAlreadyExists error
+    } else {
+      // Handle other error.
+    }
+  });
+
+client
+  .createBucket({ Bucket })
+  .then((response) => {
+    // Consume the response
+  })
+  .catch(function (error) {
+    if (error.name === "BucketAlreadyExists") {
+      // Handle BucketAlreadyExists error
+    } else {
+      // Handle other error.
+    }
+  });

--- a/src/transforms/v2-to-v3/__fixtures__/aws-error-name/service-import.output.ts
+++ b/src/transforms/v2-to-v3/__fixtures__/aws-error-name/service-import.output.ts
@@ -1,10 +1,10 @@
 import { S3 } from "@aws-sdk/client-s3";
 
+const Bucket = "bucket-name";
+
 export const func = async (client: S3) => {
   try {
-    await client.createBucket({
-      Bucket: "bucket"
-    });
+    await client.createBucket({ Bucket });
   } catch (error) {
     if (error.name === "BucketAlreadyExists") {
       // Handle BucketAlreadyExists error
@@ -12,4 +12,34 @@ export const func = async (client: S3) => {
       throw error;
     }
   }
+}
+
+export const funcPromiseCatchArrowFn = async (client: S3) => {
+  client
+    .createBucket({ Bucket })
+    .then((response) => {
+      // Consume the response
+    })
+    .catch((error) => {
+      if (error.name === "BucketAlreadyExists") {
+        // Handle BucketAlreadyExists error
+      } else {
+        // Handle other error.
+      }
+    });
+}
+
+export const funcPromiseCatchFn = async (client: S3) => {
+  client
+    .createBucket({ Bucket })
+    .then((response) => {
+      // Consume the response
+    })
+    .catch(function (error) {
+      if (error.name === "BucketAlreadyExists") {
+        // Handle BucketAlreadyExists error
+      } else {
+        // Handle other error.
+      }
+    });
 }

--- a/src/transforms/v2-to-v3/apis/renameErrorCodeWithName.ts
+++ b/src/transforms/v2-to-v3/apis/renameErrorCodeWithName.ts
@@ -2,6 +2,19 @@ import { Collection, JSCodeshift, TryStatement } from "jscodeshift";
 
 import { ClientIdentifier } from "../types";
 
+const renameCodeWithName = (
+  j: JSCodeshift,
+  source: Collection<unknown>,
+  errorName: string
+): void => {
+  source
+    .find(j.MemberExpression, {
+      object: { type: "Identifier", name: errorName },
+      property: { type: "Identifier", name: "code" },
+    })
+    .replaceWith(() => j.memberExpression(j.identifier(errorName), j.identifier("name")));
+};
+
 // Renames error.code with error.name.
 export const renameErrorCodeWithName = (
   j: JSCodeshift,
@@ -31,18 +44,7 @@ export const renameErrorCodeWithName = (
           return;
         }
 
-        j(catchClause.body)
-          .find(j.MemberExpression, {
-            object: {
-              type: "Identifier",
-              name: errorParam.name,
-            },
-            property: {
-              type: "Identifier",
-              name: "code",
-            },
-          })
-          .replaceWith(() => j.memberExpression(errorParam, j.identifier("name")));
+        renameCodeWithName(j, j(catchClause.body), errorParam.name);
       });
   }
 };


### PR DESCRIPTION
### Issue

A variant of https://github.com/aws/aws-sdk-js-codemod/pull/808 with error.code accessed in promise.catch

### Description

Transform checks for error.code to error.name in Promise.prototype.catch()

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
