### PR TITLE
Transform checks for error.code to error.name in promise failure callbacks

### DIFF
--- a/.changeset/new-meals-sell.md
+++ b/.changeset/new-meals-sell.md
@@ -1,0 +1,5 @@
+---
+"aws-sdk-js-codemod": patch
+---
+
+Transform checks for error.code to error.name in promise failure callbacks

--- a/src/transforms/v2-to-v3/__fixtures__/aws-error-name/global-import.input.js
+++ b/src/transforms/v2-to-v3/__fixtures__/aws-error-name/global-import.input.js
@@ -40,3 +40,19 @@ client
       // Handle other error.
     }
   });
+
+client
+  .createBucket({ Bucket })
+  .promise()
+  .then(
+    (response) => {
+      // Consume the response
+    },
+    (error) => {
+      if (error.code === "BucketAlreadyExists") {
+        // Handle BucketAlreadyExists error
+      } else {
+        // Handle other error.
+      }
+    }
+  );

--- a/src/transforms/v2-to-v3/__fixtures__/aws-error-name/global-import.input.ts
+++ b/src/transforms/v2-to-v3/__fixtures__/aws-error-name/global-import.input.ts
@@ -45,3 +45,21 @@ export const funcPromiseCatchFn = async (client: AWS.S3) => {
       }
     });
 }
+
+export const funcPromiseCatchCallback = async (client: AWS.S3) => {
+  client
+    .createBucket({ Bucket })
+    .promise()
+    .then(
+      (response) => {
+        // Consume the response
+      },
+      (error) => {
+        if (error.code === "BucketAlreadyExists") {
+          // Handle BucketAlreadyExists error
+        } else {
+          // Handle other error.
+        }
+      }
+    );
+}

--- a/src/transforms/v2-to-v3/__fixtures__/aws-error-name/global-import.output.js
+++ b/src/transforms/v2-to-v3/__fixtures__/aws-error-name/global-import.output.js
@@ -38,3 +38,18 @@ client
       // Handle other error.
     }
   });
+
+client
+  .createBucket({ Bucket })
+  .then(
+    (response) => {
+      // Consume the response
+    },
+    (error) => {
+      if (error.name === "BucketAlreadyExists") {
+        // Handle BucketAlreadyExists error
+      } else {
+        // Handle other error.
+      }
+    }
+  );

--- a/src/transforms/v2-to-v3/__fixtures__/aws-error-name/global-import.output.ts
+++ b/src/transforms/v2-to-v3/__fixtures__/aws-error-name/global-import.output.ts
@@ -43,3 +43,20 @@ export const funcPromiseCatchFn = async (client: S3) => {
       }
     });
 }
+
+export const funcPromiseCatchCallback = async (client: S3) => {
+  client
+    .createBucket({ Bucket })
+    .then(
+      (response) => {
+        // Consume the response
+      },
+      (error) => {
+        if (error.name === "BucketAlreadyExists") {
+          // Handle BucketAlreadyExists error
+        } else {
+          // Handle other error.
+        }
+      }
+    );
+}

--- a/src/transforms/v2-to-v3/__fixtures__/aws-error-name/service-import.input.js
+++ b/src/transforms/v2-to-v3/__fixtures__/aws-error-name/service-import.input.js
@@ -40,3 +40,19 @@ client
       // Handle other error.
     }
   });
+
+client
+  .createBucket({ Bucket })
+  .promise()
+  .then(
+    (response) => {
+      // Consume the response
+    },
+    (error) => {
+      if (error.code === "BucketAlreadyExists") {
+        // Handle BucketAlreadyExists error
+      } else {
+        // Handle other error.
+      }
+    }
+  );

--- a/src/transforms/v2-to-v3/__fixtures__/aws-error-name/service-import.input.ts
+++ b/src/transforms/v2-to-v3/__fixtures__/aws-error-name/service-import.input.ts
@@ -45,3 +45,21 @@ export const funcPromiseCatchFn = async (client: S3) => {
       }
     });
 }
+
+export const funcPromiseCatchCallback = async (client: S3) => {
+  client
+    .createBucket({ Bucket })
+    .promise()
+    .then(
+      (response) => {
+        // Consume the response
+      },
+      (error) => {
+        if (error.code === "BucketAlreadyExists") {
+          // Handle BucketAlreadyExists error
+        } else {
+          // Handle other error.
+        }
+      }
+    );
+}

--- a/src/transforms/v2-to-v3/__fixtures__/aws-error-name/service-import.output.js
+++ b/src/transforms/v2-to-v3/__fixtures__/aws-error-name/service-import.output.js
@@ -38,3 +38,19 @@ client
       // Handle other error.
     }
   });
+
+client
+  .createBucket({ Bucket })
+  .then(
+    (response) => {
+      // Consume the response
+    },
+    (error) => {
+      if (error.name === "BucketAlreadyExists") {
+        // Handle BucketAlreadyExists error
+      } else {
+        // Handle other error.
+      }
+    }
+  );
+  

--- a/src/transforms/v2-to-v3/__fixtures__/aws-error-name/service-import.output.ts
+++ b/src/transforms/v2-to-v3/__fixtures__/aws-error-name/service-import.output.ts
@@ -43,3 +43,20 @@ export const funcPromiseCatchFn = async (client: S3) => {
       }
     });
 }
+
+export const funcPromiseCatchCallback = async (client: S3) => {
+  client
+    .createBucket({ Bucket })
+    .then(
+      (response) => {
+        // Consume the response
+      },
+      (error) => {
+        if (error.name === "BucketAlreadyExists") {
+          // Handle BucketAlreadyExists error
+        } else {
+          // Handle other error.
+        }
+      }
+    );
+}


### PR DESCRIPTION
### Issue

Variation of https://github.com/aws/aws-sdk-js-codemod/pull/810

### Description

Transforms checks for error.code to error.name in promise failure callbacks

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
