### PR TITLE
Give id-token write permissions to release workflow for npm provenance

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -10,6 +10,8 @@ jobs:
   release:
     needs: call-build
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
### Issue

Refs: https://github.com/aws/aws-sdk-js-codemod/pull/813#issuecomment-2020807392

### Description

Give id-token write permissions to release workflow for npm provenance

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
