### PR TITLE
Give contents and pull-requests write permissions to release workflow

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -11,7 +11,9 @@ jobs:
     needs: call-build
     runs-on: ubuntu-latest
     permissions:
+      contents: write
       id-token: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
### Issue

Release workflow failure in https://github.com/aws/aws-sdk-js-codemod/pull/816#issuecomment-2020847642
Referred permissions for related package which uses changesets with npm provenance https://github.com/sigstore/sigstore-js/blob/3b0c2739190f06ce4fc0894b39a447f0f9b436cd/.github/workflows/release.yml#L17-L20

### Description

Give contents and pull-requests write permissions to release workflow

### Testing

To be tested with post merge with GitHub Actions

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
