### PR TITLE
Auto-correct errors in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,10 +27,12 @@
   ],
   "main": "dist/cli.js",
   "types": "dist/cli.d.ts",
-  "bin": "bin/aws-sdk-js-codemod",
+  "bin": {
+    "aws-sdk-js-codemod": "bin/aws-sdk-js-codemod"
+  },
   "repository": {
     "type": "git",
-    "url": "https://github.com/aws/aws-sdk-js-codemod.git"
+    "url": "git+https://github.com/aws/aws-sdk-js-codemod.git"
   },
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
### Issue

The errors in package.json while examining npm publish failures in https://github.com/aws/aws-sdk-js-codemod/pull/813#issuecomment-2020807392

```console
🦋  error npm WARN publish npm auto-corrected some errors in your package.json when publishing.  Please run "npm pkg fix" to address these errors.
🦋  error npm WARN publish errors corrected:
🦋  error npm WARN publish "bin" was converted to an object
🦋  error npm WARN publish "repository.url" was normalized to "git+https://github.com/aws/aws-sdk-js-codemod.git"
```

### Description

Auto-correct errors in package.json using `npm pkg fix`

### Testing

N/A, the errors were auto corrected by npm cli, and will not appear during publish.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
