### PR TITLE
Update formatting for package.json bin as per yarn

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,9 +27,7 @@
   ],
   "main": "dist/cli.js",
   "types": "dist/cli.d.ts",
-  "bin": {
-    "aws-sdk-js-codemod": "bin/aws-sdk-js-codemod"
-  },
+  "bin": "bin/aws-sdk-js-codemod",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/aws/aws-sdk-js-codemod.git"


### PR DESCRIPTION
### Issue

* Follow-up to https://github.com/aws/aws-sdk-js-codemod/pull/818
* the issue is in `npm pkg fix` command https://github.com/npm/cli/issues/7302

### Description

yarn@4.1.1 formats package.json `bin` entry to a short form every time install is run.

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
