### PR TITLE
Use 'not supported' constant for early return

### DIFF
--- a/.changeset/four-badgers-care.md
+++ b/.changeset/four-badgers-care.md
@@ -1,0 +1,5 @@
+---
+"aws-sdk-js-codemod": patch
+---
+
+Use 'not supported' constant for early return

--- a/src/transforms/v2-to-v3/apis/addNotSupportedClientComments.ts
+++ b/src/transforms/v2-to-v3/apis/addNotSupportedClientComments.ts
@@ -1,6 +1,6 @@
 import { Collection, JSCodeshift } from "jscodeshift";
 
-import { FUNCTION_TYPE_LIST, S3 } from "../config";
+import { FUNCTION_TYPE_LIST, NOT_SUPPORTED_COMMENT, S3 } from "../config";
 import { ClientIdentifier } from "../types";
 import { getClientApiCallExpression } from "./getClientApiCallExpression";
 import { getClientWaiterCallExpression } from "./getClientWaiterCallExpression";
@@ -29,11 +29,7 @@ export const addNotSupportedClientComments = (
 
           if (FUNCTION_TYPE_LIST.includes(args[args.length - 1].type)) {
             const comments = callExpression.node.comments || [];
-            comments.push(
-              j.commentLine(
-                " Waiters with callbacks are not supported in AWS SDK for JavaScript (v3)."
-              )
-            );
+            comments.push(j.commentLine(` Waiters with callbacks are ${NOT_SUPPORTED_COMMENT}.`));
             comments.push(
               j.commentLine(
                 " Please convert to `await client.waitFor(state, params).promise()`, and re-run aws-sdk-js-codemod."
@@ -68,9 +64,7 @@ export const addNotSupportedClientComments = (
             if (FUNCTION_TYPE_LIST.includes(args[args.length - 1].type)) {
               const comments = callExpression.node.comments || [];
               comments.push(
-                j.commentLine(
-                  ` ${apiDescription} with callbacks are not supported in AWS SDK for JavaScript (v3).`
-                )
+                j.commentLine(` ${apiDescription} with callbacks are ${NOT_SUPPORTED_COMMENT}.`)
               );
               comments.push(
                 j.commentLine(

--- a/src/transforms/v2-to-v3/config/constants.ts
+++ b/src/transforms/v2-to-v3/config/constants.ts
@@ -13,3 +13,5 @@ export const FUNCTION_TYPE_LIST = [
   "ArrowFunctionExpression",
 ];
 export const STRING_LITERAL_TYPE_LIST = ["Literal", "StringLiteral"];
+
+export const NOT_SUPPORTED_COMMENT = "not supported in AWS SDK for JavaScript (v3)";

--- a/src/transforms/v2-to-v3/transformer.ts
+++ b/src/transforms/v2-to-v3/transformer.ts
@@ -25,7 +25,7 @@ import {
   getClientNamesFromGlobal,
   getClientNamesRecord,
 } from "./client-names";
-import { S3 } from "./config";
+import { NOT_SUPPORTED_COMMENT, S3 } from "./config";
 import { addClientModules, getGlobalNameFromModule, getImportType, removeModules } from "./modules";
 import { removeTypesFromTSQualifiedName, replaceTSTypeReference } from "./ts-type";
 import {
@@ -70,7 +70,7 @@ const transformer = async (file: FileInfo, api: API) => {
     addNotSupportedClientComments(j, source, { v2ClientName, clientIdentifiers });
   }
 
-  if (source.toSource() !== file.source) {
+  if (source.toSource().includes(NOT_SUPPORTED_COMMENT)) {
     return source.toSource();
   }
 


### PR DESCRIPTION
### Issue

Required for changes like in https://github.com/aws/aws-sdk-js-codemod/pull/845, where we plan to modify the deep path imports before transformation.

The support for deep path import for DocumentClient will also be added similarly in https://github.com/aws/aws-sdk-js-codemod/pull/847

### Description

Use not support string for early return

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
