### PR TITLE
Replace config credentialsProvider with credentials

### DIFF
--- a/.changeset/honest-readers-confess.md
+++ b/.changeset/honest-readers-confess.md
@@ -1,0 +1,5 @@
+---
+"aws-sdk-js-codemod": patch
+---
+
+Replace config credentialsProvider with credentials

--- a/src/transforms/v2-to-v3/__fixtures__/config/credentialsProvider.input.js
+++ b/src/transforms/v2-to-v3/__fixtures__/config/credentialsProvider.input.js
@@ -1,0 +1,8 @@
+import AWS from "aws-sdk";
+
+const config = new AWS.Config({
+  credentialProvider: () => Promise.resolve({
+    accessKeyId: "AKID",
+    secretAccessKey: "SECRET"
+  })
+});

--- a/src/transforms/v2-to-v3/__fixtures__/config/credentialsProvider.output.js
+++ b/src/transforms/v2-to-v3/__fixtures__/config/credentialsProvider.output.js
@@ -1,0 +1,9 @@
+import AWS from "aws-sdk";
+
+const config = {
+  // The credentials in JS SDK v3 accepts providers.
+  credentials: () => Promise.resolve({
+    accessKeyId: "AKID",
+    secretAccessKey: "SECRET"
+  })
+};

--- a/src/transforms/v2-to-v3/__fixtures__/config/credentialsProvider.output.js
+++ b/src/transforms/v2-to-v3/__fixtures__/config/credentialsProvider.output.js
@@ -1,6 +1,5 @@
-import AWS from "aws-sdk";
-
 const config = {
+  // The key credentialProvider is renamed to credentials.
   // The credentials in JS SDK v3 accepts providers.
   credentials: () => Promise.resolve({
     accessKeyId: "AKID",

--- a/src/transforms/v2-to-v3/config/AWS_CONFIG_KEY_MAP.ts
+++ b/src/transforms/v2-to-v3/config/AWS_CONFIG_KEY_MAP.ts
@@ -22,7 +22,7 @@ export const AWS_CONFIG_KEY_MAP: Record<string, AwsConfigKeyStatus> = {
     deprecationMessage: "The clock skew correction is applied by default.",
   },
   credentials: {},
-  credentialsProvider: {
+  credentialProvider: {
     newKeyName: "credentials",
     description: "The credentials in JS SDK v3 accepts providers.",
   },

--- a/src/transforms/v2-to-v3/config/AWS_CONFIG_KEY_MAP.ts
+++ b/src/transforms/v2-to-v3/config/AWS_CONFIG_KEY_MAP.ts
@@ -22,6 +22,10 @@ export const AWS_CONFIG_KEY_MAP: Record<string, AwsConfigKeyStatus> = {
     deprecationMessage: "The clock skew correction is applied by default.",
   },
   credentials: {},
+  credentialsProvider: {
+    newKeyName: "credentials",
+    description: "The credentials in JS SDK v3 accepts providers.",
+  },
   endpoint: {},
   endpointCacheSize: {},
   endpointDiscoveryEnabled: {},


### PR DESCRIPTION
### Issue

Fixes: https://github.com/aws/aws-sdk-js-codemod/issues/691

### Description

Replace config credentialsProvider with credentials

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
