### PR TITLE
Skip adding unsupported comment for config customUserAgent

### DIFF
--- a/.changeset/brown-badgers-cheer.md
+++ b/.changeset/brown-badgers-cheer.md
@@ -1,0 +1,5 @@
+---
+"aws-sdk-js-codemod": patch
+---
+
+Skip adding unsupported comment for config customUserAgent

--- a/src/transforms/v2-to-v3/__fixtures__/config/customUserAgent.input.js
+++ b/src/transforms/v2-to-v3/__fixtures__/config/customUserAgent.input.js
@@ -1,0 +1,5 @@
+import AWS from "aws-sdk";
+
+const config = new AWS.Config({
+  customUserAgent: "MyApp/1.0.0"
+});

--- a/src/transforms/v2-to-v3/__fixtures__/config/customUserAgent.output.js
+++ b/src/transforms/v2-to-v3/__fixtures__/config/customUserAgent.output.js
@@ -1,0 +1,3 @@
+const config = {
+  customUserAgent: "MyApp/1.0.0"
+};

--- a/src/transforms/v2-to-v3/config/AWS_CONFIG_KEY_MAP.ts
+++ b/src/transforms/v2-to-v3/config/AWS_CONFIG_KEY_MAP.ts
@@ -26,6 +26,7 @@ export const AWS_CONFIG_KEY_MAP: Record<string, AwsConfigKeyStatus> = {
     newKeyName: "credentials",
     description: "The credentials in JS SDK v3 accepts providers.",
   },
+  customUserAgent: {},
   endpoint: {},
   endpointCacheSize: {},
   endpointDiscoveryEnabled: {},


### PR DESCRIPTION
### Issue

Fixes: https://github.com/aws/aws-sdk-js-codemod/issues/723

### Description

Skip adding unsupported comment for config customUserAgent

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
