### PR TITLE
Remove .promise() calls from APIs called from new client

### DIFF
--- a/.changeset/rotten-ears-move.md
+++ b/.changeset/rotten-ears-move.md
@@ -1,0 +1,5 @@
+---
+"aws-sdk-js-codemod": patch
+---
+
+Remove .promise() calls from APIs called from new client

--- a/src/transforms/v2-to-v3/__fixtures__/api-promise/global-client-creation.input.js
+++ b/src/transforms/v2-to-v3/__fixtures__/api-promise/global-client-creation.input.js
@@ -1,0 +1,3 @@
+import AWS from "aws-sdk";
+
+const data = await new AWS.DynamoDB().listTables().promise();

--- a/src/transforms/v2-to-v3/__fixtures__/api-promise/global-client-creation.output.js
+++ b/src/transforms/v2-to-v3/__fixtures__/api-promise/global-client-creation.output.js
@@ -1,0 +1,3 @@
+import { DynamoDB } from "@aws-sdk/client-dynamodb";
+
+const data = await new DynamoDB().listTables();

--- a/src/transforms/v2-to-v3/__fixtures__/api-promise/service-client-creation.input.js
+++ b/src/transforms/v2-to-v3/__fixtures__/api-promise/service-client-creation.input.js
@@ -1,0 +1,3 @@
+import { DynamoDB } from "aws-sdk";
+
+const data = await new DynamoDB().listTables().promise();

--- a/src/transforms/v2-to-v3/__fixtures__/api-promise/service-client-creation.output.js
+++ b/src/transforms/v2-to-v3/__fixtures__/api-promise/service-client-creation.output.js
@@ -1,0 +1,3 @@
+import { DynamoDB } from "@aws-sdk/client-dynamodb";
+
+const data = await new DynamoDB().listTables();

--- a/src/transforms/v2-to-v3/apis/removePromiseCalls.ts
+++ b/src/transforms/v2-to-v3/apis/removePromiseCalls.ts
@@ -3,12 +3,69 @@ import { Collection, Identifier, JSCodeshift } from "jscodeshift";
 import { ClientIdentifier } from "../types";
 import { removePromiseForCallExpression } from "./removePromiseForCallExpression";
 
+export interface RemovePromiseCallsOptions {
+  v2GlobalName?: string;
+  v2ClientName: string;
+  v2ClientLocalName: string;
+  clientIdentifiers: ClientIdentifier[];
+}
+
 // Removes .promise() from client API calls.
 export const removePromiseCalls = (
   j: JSCodeshift,
   source: Collection<unknown>,
-  clientIdentifiers: ClientIdentifier[]
+  { v2GlobalName, v2ClientName, v2ClientLocalName, clientIdentifiers }: RemovePromiseCallsOptions
 ): void => {
+  // Remove .promise() for API calls from client creation from global name.
+  if (v2GlobalName) {
+    source
+      .find(j.CallExpression, {
+        callee: {
+          type: "MemberExpression",
+          object: {
+            type: "CallExpression",
+            callee: {
+              type: "MemberExpression",
+              object: {
+                type: "NewExpression",
+                callee: {
+                  type: "MemberExpression",
+                  object: { type: "Identifier", name: v2GlobalName },
+                  property: { type: "Identifier", name: v2ClientName },
+                },
+              },
+            },
+          },
+          property: { type: "Identifier", name: "promise" },
+        },
+      })
+      .forEach((callExpression) => {
+        removePromiseForCallExpression(j, callExpression);
+      });
+  }
+
+  // Remove .promise() for API calls client creation from local name.
+  source
+    .find(j.CallExpression, {
+      callee: {
+        type: "MemberExpression",
+        object: {
+          type: "CallExpression",
+          callee: {
+            type: "MemberExpression",
+            object: {
+              type: "NewExpression",
+              callee: { type: "Identifier", name: v2ClientLocalName },
+            },
+          },
+        },
+        property: { type: "Identifier", name: "promise" },
+      },
+    })
+    .forEach((callExpression) => {
+      removePromiseForCallExpression(j, callExpression);
+    });
+
   for (const clientId of clientIdentifiers) {
     // Remove .promise() from client API calls.
     source

--- a/src/transforms/v2-to-v3/transformer.ts
+++ b/src/transforms/v2-to-v3/transformer.ts
@@ -107,7 +107,7 @@ const transformer = async (file: FileInfo, api: API) => {
       replaceS3UploadApi(j, source, clientIdentifiers);
     }
 
-    removePromiseCalls(j, source, clientIdentifiers);
+    removePromiseCalls(j, source, { ...v2Options, clientIdentifiers });
     addEmptyObjectForUndefined(j, source, clientIdentifiers);
     renameErrorCodeWithName(j, source, clientIdentifiers);
 


### PR DESCRIPTION
### Issue

Fixes: https://github.com/aws/aws-sdk-js-codemod/issues/684

### Description

Remove .promise() calls from APIs called from new client

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
