### PR TITLE
State api name "is" not supported in comments

### DIFF
--- a/.changeset/strange-crabs-guess.md
+++ b/.changeset/strange-crabs-guess.md
@@ -1,0 +1,5 @@
+---
+"aws-sdk-js-codemod": patch
+---
+
+State api name "is" not supported in comments

--- a/src/transforms/v2-to-v3/__fixtures__/s3-get-signed-url/callback.output.js
+++ b/src/transforms/v2-to-v3/__fixtures__/s3-get-signed-url/callback.output.js
@@ -3,7 +3,7 @@ import AWS from "aws-sdk";
 const s3 = new AWS.S3();
 const params = { Bucket: "bucket", Key: "key" };
 
-// S3 getSignedUrl with callbacks are not supported in AWS SDK for JavaScript (v3).
+// S3 getSignedUrl with callbacks is not supported in AWS SDK for JavaScript (v3).
 // Please convert to 'client.getSignedUrl(apiName, options)', and re-run aws-sdk-js-codemod.
 s3.getSignedUrl("getObject", params, function (err, url) {
   console.log('The URL is', url);

--- a/src/transforms/v2-to-v3/__fixtures__/s3-upload/callback-arrow-fn.output.js
+++ b/src/transforms/v2-to-v3/__fixtures__/s3-upload/callback-arrow-fn.output.js
@@ -8,7 +8,7 @@ const uploadParams = {
   Key: "Key",
 };
 
-// S3 ManagedUpload with callbacks are not supported in AWS SDK for JavaScript (v3).
+// S3 ManagedUpload with callbacks is not supported in AWS SDK for JavaScript (v3).
 // Please convert to 'await client.upload(params, options).promise()', and re-run aws-sdk-js-codemod.
 client.upload(uploadParams, (err, data) => {
   if (err) console.log(err, err.stack); // an error occurred

--- a/src/transforms/v2-to-v3/__fixtures__/s3-upload/callback.output.js
+++ b/src/transforms/v2-to-v3/__fixtures__/s3-upload/callback.output.js
@@ -8,7 +8,7 @@ const uploadParams = {
   Key: "Key",
 };
 
-// S3 ManagedUpload with callbacks are not supported in AWS SDK for JavaScript (v3).
+// S3 ManagedUpload with callbacks is not supported in AWS SDK for JavaScript (v3).
 // Please convert to 'await client.upload(params, options).promise()', and re-run aws-sdk-js-codemod.
 client.upload(uploadParams, function (err, data) {
   if (err) console.log(err, err.stack); // an error occurred

--- a/src/transforms/v2-to-v3/apis/addNotSupportedClientComments.ts
+++ b/src/transforms/v2-to-v3/apis/addNotSupportedClientComments.ts
@@ -64,7 +64,7 @@ export const addNotSupportedClientComments = (
             if (FUNCTION_TYPE_LIST.includes(args[args.length - 1].type)) {
               const comments = callExpression.node.comments || [];
               comments.push(
-                j.commentLine(` ${apiDescription} with callbacks are ${NOT_SUPPORTED_COMMENT}.`)
+                j.commentLine(` ${apiDescription} with callbacks is ${NOT_SUPPORTED_COMMENT}.`)
               );
               comments.push(
                 j.commentLine(


### PR DESCRIPTION
### Issue

Noticed in https://github.com/aws/aws-sdk-js-codemod/pull/863

### Description

State api name "is" not supported in comments

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
