### PR TITLE
chore(deps-dev): bump yarn to 4.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
   "engines": {
     "node": ">=14.0.0"
   },
-  "packageManager": "yarn@4.3.0",
+  "packageManager": "yarn@4.3.1",
   "lint-staged": {
     "*.ts": [
       "eslint --fix",


### PR DESCRIPTION
### Issue

* Required for bumping TypeScript to 5.5.2
* Release Notes https://github.com/yarnpkg/berry/releases/tag/%40yarnpkg%2Fcli%2F4.3.1

### Description

Bump yarn to 4.3.1

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
