### PR TITLE
chore: drop support for Node.js 14.x

### DIFF
--- a/.changeset/new-coats-fry.md
+++ b/.changeset/new-coats-fry.md
@@ -1,0 +1,5 @@
+---
+"aws-sdk-js-codemod": minor
+---
+
+Drop support for Node.js 14.x

--- a/.changeset/new-coats-fry.md
+++ b/.changeset/new-coats-fry.md
@@ -1,5 +1,5 @@
 ---
-"aws-sdk-js-codemod": minor
+"aws-sdk-js-codemod": major
 ---
 
 Drop support for Node.js 14.x

--- a/package.json
+++ b/package.json
@@ -44,9 +44,9 @@
   },
   "devDependencies": {
     "@changesets/cli": "^2.27.1",
-    "@tsconfig/node14": "^14.1.2",
+    "@tsconfig/node16": "^16.1.3",
     "@types/jscodeshift": "^0.11.11",
-    "@types/node": "^14.18.33",
+    "@types/node": "^16.18.101",
     "@typescript-eslint/eslint-plugin": "^7.14.1",
     "@typescript-eslint/parser": "^7.14.1",
     "aws-sdk": "2.1641.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,6 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
-    "esModuleInterop": true,
     "outDir": "dist",
     "resolveJsonModule": true,
     "rootDir": "src"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1313,10 +1313,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tsconfig/node14@npm:^14.1.2":
-  version: 14.1.2
-  resolution: "@tsconfig/node14@npm:14.1.2"
-  checksum: 10c0/61235f8f85ac56cd9cab58f8e6eedbe13d2454188b5987ddf499827a8683283983f564d48db904a650c5ce087d5dc827a891900edbf6d7a7e38aacda4194578a
+"@tsconfig/node16@npm:^16.1.3":
+  version: 16.1.3
+  resolution: "@tsconfig/node16@npm:16.1.3"
+  checksum: 10c0/4349c513719c5e1ef1995cc0c09d6099761ec0f3814a7165bf0622dfa76b2cc8580fac022bf1863f7eb6e34ced280c6d2dfb3750b6e1e2c5b96cb4e7e4004f04
   languageName: node
   linkType: hard
 
@@ -1358,10 +1358,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:^14.18.33":
-  version: 14.18.63
-  resolution: "@types/node@npm:14.18.63"
-  checksum: 10c0/626a371419a6a0e11ca460b22bb4894abe5d75c303739588bc96267e380aa8b90ba5a87bc552400584f0ac2a84b5c458dadcbcf0dfd2396ebeb765f7a7f95893
+"@types/node@npm:^16.18.101":
+  version: 16.18.101
+  resolution: "@types/node@npm:16.18.101"
+  checksum: 10c0/b28a490d9230d37c19e3123c04c857c9e363225525979a468c3e4897bb48165ed3db2237ed86804c18d4a79a1bb14889eb1823c6187e8b28bdec214236918eef
   languageName: node
   linkType: hard
 
@@ -1842,9 +1842,9 @@ __metadata:
   resolution: "aws-sdk-js-codemod@workspace:."
   dependencies:
     "@changesets/cli": "npm:^2.27.1"
-    "@tsconfig/node14": "npm:^14.1.2"
+    "@tsconfig/node16": "npm:^16.1.3"
     "@types/jscodeshift": "npm:^0.11.11"
-    "@types/node": "npm:^14.18.33"
+    "@types/node": "npm:^16.18.101"
     "@typescript-eslint/eslint-plugin": "npm:^7.14.1"
     "@typescript-eslint/parser": "npm:^7.14.1"
     aws-sdk: "npm:2.1641.0"


### PR DESCRIPTION
### Issue

* The JS SDK v3 dropped support for Node.js 14.x in https://github.com/aws/aws-sdk-js-v3/pull/6034
* The jscodeshift dependency dropped support for Node.js 14.x in https://github.com/facebook/jscodeshift/pull/588

### Description

Drop support for Node.js 14.x

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
