### PR TITLE
Turn off @typescript-eslint/ban-ts-comment

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -21,7 +21,8 @@
         "format": ["camelCase", "UPPER_CASE", "PascalCase"],
         "leadingUnderscore": "allow"
       }
-    ]
+    ],
+    "@typescript-eslint/ban-ts-comment": "off"
   },
   "ignorePatterns": ["__fixtures__"]
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -21,7 +21,6 @@
 // Most of the code from here is from bin/jscodeshift.js
 // It's kept that way so that users can reuse jscodeshift options.
 
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 import path from "path";
 import Runner from "jscodeshift/dist/Runner";

--- a/src/transforms/v2-to-v3/client-instances/getObjectWithUpdatedAwsConfigKeys.ts
+++ b/src/transforms/v2-to-v3/client-instances/getObjectWithUpdatedAwsConfigKeys.ts
@@ -113,7 +113,6 @@ export const getObjectWithUpdatedAwsConfigKeys = (
     })
     .filter((property) => property !== undefined);
 
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore is Argument is not assignable to parameter
   return j.objectExpression(updatedProperties);
 };

--- a/src/transforms/v2-to-v3/ts-type/getTypeForString.ts
+++ b/src/transforms/v2-to-v3/ts-type/getTypeForString.ts
@@ -30,7 +30,7 @@ export const getTypeForString = (
     const typeArgument = getTypeForString(j, v2ClientLocalName, type);
     return j.tsTypeReference.from({
       typeName: j.identifier("Array"),
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+
       // @ts-ignore
       typeParameters: j.tsTypeParameterInstantiation([typeArgument]),
     });
@@ -42,7 +42,7 @@ export const getTypeForString = (
     const typeArgument = getTypeForString(j, v2ClientLocalName, type);
     return j.tsTypeReference.from({
       typeName: j.identifier("Record"),
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+
       // @ts-ignore
       typeParameters: j.tsTypeParameterInstantiation([j.tsStringKeyword(), typeArgument]),
     });

--- a/src/transforms/v2-to-v3/utils/getMostUsedStringLiteralQuote.ts
+++ b/src/transforms/v2-to-v3/utils/getMostUsedStringLiteralQuote.ts
@@ -19,7 +19,6 @@ export const getMostUsedStringLiteralQuote = (
 
     // Check if the literal value is a string and contains single quotes
     if (typeof value === "string") {
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore Property 'raw' does not exist on type 'Literal'.
       const rawValue = path.node.raw || path.node.extra?.raw || "";
       if (rawValue.startsWith("'")) {

--- a/src/transforms/v2-to-v3/utils/isTrailingCommaUsed.ts
+++ b/src/transforms/v2-to-v3/utils/isTrailingCommaUsed.ts
@@ -2,7 +2,6 @@ import { Collection, JSCodeshift } from "jscodeshift";
 
 export const isTrailingCommaUsed = (j: JSCodeshift, source: Collection<unknown>) => {
   for (const node of source.find(j.ObjectExpression).nodes()) {
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore Property 'extra' does not exist on type 'ObjectExpression'.
     if (node.extra && node.extra.trailingComma) {
       return true;

--- a/src/utils/getJsCodeshiftParser.ts
+++ b/src/utils/getJsCodeshiftParser.ts
@@ -1,7 +1,6 @@
 // Most of the code from here is from bin/jscodeshift.js
 // It's kept that way so that users can reuse jscodeshift options.
 
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 
 import { readFileSync } from "fs";
@@ -9,7 +8,6 @@ import { dirname, join } from "path";
 import { DEFAULT_EXTENSIONS } from "@babel/core";
 import argsParser from "jscodeshift/dist/argsParser";
 
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore: package.json will be imported from dist folders
 import { version } from "../../package.json";
 


### PR DESCRIPTION
### Issue

The equivalent is not available in biome which we're planing to move to in https://github.com/aws/aws-sdk-js-codemod/pull/872. It's being worked on in https://github.com/biomejs/biome/issues/713

In codemod, we've only used ts comments when reusing code from jscodeshift, or when there are type issues in implementation which are tested with unit tests.

### Description

Turn off @typescript-eslint/ban-ts-comment

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
