### PR TITLE
Check for package.json exists before reading

### DIFF
--- a/.changeset/moody-mugs-fetch.md
+++ b/.changeset/moody-mugs-fetch.md
@@ -1,0 +1,5 @@
+---
+"aws-sdk-js-codemod": patch
+---
+
+Check for package.json exists before reading

--- a/src/utils/getJsCodeshiftParser.ts
+++ b/src/utils/getJsCodeshiftParser.ts
@@ -3,7 +3,7 @@
 
 // @ts-nocheck
 
-import { readFileSync } from "fs";
+import { existsSync, readFileSync } from "fs";
 import { dirname, join } from "path";
 import { DEFAULT_EXTENSIONS } from "@babel/core";
 import argsParser from "jscodeshift/dist/argsParser";
@@ -15,11 +15,11 @@ const requirePackage = (name: string) => {
   const entry = require.resolve(name);
   let dir = dirname(entry);
   while (dir !== "/") {
-    try {
-      // eslint-disable-next-line @typescript-eslint/no-var-requires
-      const pkg = require(join(dir, "package.json"));
-      return pkg.name === name ? pkg : {};
-    } catch (error) {} // eslint-disable-line no-empty
+    const packageJsonPath = join(dir, "package.json");
+    if (existsSync(packageJsonPath)) {
+      const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8"));
+      return packageJson.name === name ? packageJson : {};
+    }
     dir = dirname(dir);
   }
   return {};


### PR DESCRIPTION
### Issue

Noticed while attempting to migrate to biome https://github.com/aws/aws-sdk-js-codemod/pull/886

### Description

Check for package.json exists before reading

### Testing

Verified that version information is printed
```console
$ ./bin/aws-sdk-js-codemod --version
aws-sdk-js-codemod: 2.0.0
- jscodeshift: 0.16.0
- recast: 0.20.5
```

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
