### PR TITLE
Convert version callback to arrow function

### DIFF
--- a/.changeset/thick-hounds-wonder.md
+++ b/.changeset/thick-hounds-wonder.md
@@ -1,0 +1,5 @@
+---
+"aws-sdk-js-codemod": patch
+---
+
+Convert version callback to arrow function

--- a/src/utils/getJsCodeshiftParser.ts
+++ b/src/utils/getJsCodeshiftParser.ts
@@ -141,13 +141,12 @@ export const getJsCodeshiftParser = () =>
     version: {
       display_index: 17,
       help: "print version and exit",
-      callback: function () {
-        return [
+      callback: () =>
+        [
           `aws-sdk-js-codemod: ${version}`,
           `- jscodeshift: ${requirePackage("jscodeshift").version}`,
           `- recast: ${requirePackage("recast").version}\n`,
-        ].join("\n");
-      },
+        ].join("\n"),
     },
     stdin: {
       display_index: 14,


### PR DESCRIPTION
### Issue

Formatted during biome upgrade in https://github.com/aws/aws-sdk-js-codemod/pull/886

### Description

Convert version callback to arrow function

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
