### PR TITLE
Use `node:` import for Node.js built-in modules

### DIFF
--- a/.changeset/slow-timers-visit.md
+++ b/.changeset/slow-timers-visit.md
@@ -1,0 +1,5 @@
+---
+"aws-sdk-js-codemod": patch
+---
+
+Use node: import for Node.js built-in modules

--- a/biome.json
+++ b/biome.json
@@ -34,7 +34,6 @@
           "options": { "syntax": "shorthand" }
         },
         "useImportType": "off",
-        "useNodejsImportProtocol": "off",
         "useTemplate": "off"
       },
       "suspicious": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -22,7 +22,7 @@
 // It's kept that way so that users can reuse jscodeshift options.
 
 // @ts-nocheck
-import path from "path";
+import path from "node:path";
 import Runner from "jscodeshift/dist/Runner";
 
 import {

--- a/src/transforms/v2-to-v3/apis/removePromiseForCallExpression.ts
+++ b/src/transforms/v2-to-v3/apis/removePromiseForCallExpression.ts
@@ -1,5 +1,5 @@
+import { emitWarning } from "node:process";
 import { ASTPath, CallExpression, JSCodeshift, MemberExpression } from "jscodeshift";
-import { emitWarning } from "process";
 
 export const removePromiseForCallExpression = (
   j: JSCodeshift,

--- a/src/transforms/v2-to-v3/transformer.spec.ts
+++ b/src/transforms/v2-to-v3/transformer.spec.ts
@@ -1,6 +1,6 @@
-import { readdirSync } from "fs";
-import { join } from "path";
-import { readFile } from "fs/promises";
+import { readdirSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
 import jscodeshift from "jscodeshift";
 import { describe, expect, it } from "vitest";
 

--- a/src/transforms/v2-to-v3/utils/getMostUsedIndentationType.ts
+++ b/src/transforms/v2-to-v3/utils/getMostUsedIndentationType.ts
@@ -1,4 +1,4 @@
-import { EOL } from "os";
+import { EOL } from "node:os";
 
 export enum IndentationType {
   TAB = "tab",

--- a/src/transforms/v2-to-v3/utils/getValueIndentedWithTabs.ts
+++ b/src/transforms/v2-to-v3/utils/getValueIndentedWithTabs.ts
@@ -1,4 +1,4 @@
-import { EOL } from "os";
+import { EOL } from "node:os";
 
 const INDENTATION_REGEX = /^(\t*)( {4})/;
 

--- a/src/utils/getJsCodeshiftParser.ts
+++ b/src/utils/getJsCodeshiftParser.ts
@@ -3,8 +3,8 @@
 
 // @ts-nocheck
 
-import { existsSync, readFileSync } from "fs";
-import { dirname, join } from "path";
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
 import { DEFAULT_EXTENSIONS } from "@babel/core";
 import argsParser from "jscodeshift/dist/argsParser";
 

--- a/src/utils/getTransforms.ts
+++ b/src/utils/getTransforms.ts
@@ -1,5 +1,5 @@
-import { readdirSync } from "fs";
-import { join } from "path";
+import { readdirSync } from "node:fs";
+import { join } from "node:path";
 
 import { AwsSdkJsCodemodTransform } from "../transforms";
 

--- a/src/utils/getUpdatedTransformFile.ts
+++ b/src/utils/getUpdatedTransformFile.ts
@@ -1,4 +1,4 @@
-import { resolve } from "path";
+import { resolve } from "node:path";
 
 export const getUpdatedTransformFile = (transformFolder: string) =>
   resolve(__dirname, "..", "transforms", transformFolder, "transformer.js");


### PR DESCRIPTION
### Issue

* Biome rule https://biomejs.dev/linter/rules/use-nodejs-import-protocol/
* Node.js docs https://nodejs.org/api/esm.html#node-imports

### Description

Use `node:` import for Node.js built-in modules

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
