### PR TITLE
Use TypeScript type import for types

### DIFF
--- a/.changeset/angry-suns-lie.md
+++ b/.changeset/angry-suns-lie.md
@@ -1,0 +1,5 @@
+---
+"aws-sdk-js-codemod": patch
+---
+
+Use TypeScript type import for types

--- a/biome.json
+++ b/biome.json
@@ -33,7 +33,6 @@
           "level": "error",
           "options": { "syntax": "shorthand" }
         },
-        "useImportType": "off",
         "useTemplate": "off"
       },
       "suspicious": {

--- a/src/transforms/v2-to-v3/apis/addEmptyObjectForUndefined.ts
+++ b/src/transforms/v2-to-v3/apis/addEmptyObjectForUndefined.ts
@@ -1,6 +1,6 @@
-import { Collection, JSCodeshift } from "jscodeshift";
+import type { Collection, JSCodeshift } from "jscodeshift";
 
-import { ClientIdentifier } from "../types";
+import type { ClientIdentifier } from "../types";
 
 // Adds an empty object, if undefined is passed for optional parameters.
 export const addEmptyObjectForUndefined = (

--- a/src/transforms/v2-to-v3/apis/addNotSupportedClientComments.ts
+++ b/src/transforms/v2-to-v3/apis/addNotSupportedClientComments.ts
@@ -1,7 +1,7 @@
-import { Collection, JSCodeshift } from "jscodeshift";
+import type { Collection, JSCodeshift } from "jscodeshift";
 
 import { FUNCTION_TYPE_LIST, NOT_SUPPORTED_COMMENT, S3 } from "../config";
-import { ClientIdentifier } from "../types";
+import type { ClientIdentifier } from "../types";
 import { getClientApiCallExpression } from "./getClientApiCallExpression";
 import { getClientWaiterCallExpression } from "./getClientWaiterCallExpression";
 import { getClientWaiterStates } from "./getClientWaiterStates";

--- a/src/transforms/v2-to-v3/apis/addPromiseRemovalComments.ts
+++ b/src/transforms/v2-to-v3/apis/addPromiseRemovalComments.ts
@@ -1,4 +1,4 @@
-import { Collection, JSCodeshift } from "jscodeshift";
+import type { Collection, JSCodeshift } from "jscodeshift";
 
 export const addPromiseRemovalComments = (j: JSCodeshift, source: Collection<unknown>): void => {
   // Add comment for .promise() calls which weren't removed.

--- a/src/transforms/v2-to-v3/apis/getArgsWithoutWaiterConfig.ts
+++ b/src/transforms/v2-to-v3/apis/getArgsWithoutWaiterConfig.ts
@@ -1,4 +1,4 @@
-import { ObjectExpression, ObjectProperty, Property } from "jscodeshift";
+import type { ObjectExpression, ObjectProperty, Property } from "jscodeshift";
 
 import { OBJECT_PROPERTY_TYPE_LIST } from "../config";
 

--- a/src/transforms/v2-to-v3/apis/getClientApiCallExpression.ts
+++ b/src/transforms/v2-to-v3/apis/getClientApiCallExpression.ts
@@ -1,6 +1,6 @@
-import { CallExpression } from "jscodeshift";
+import type { CallExpression } from "jscodeshift";
 
-import { ClientIdentifier } from "../types";
+import type { ClientIdentifier } from "../types";
 
 export const getClientApiCallExpression = (
   clientId: ClientIdentifier,

--- a/src/transforms/v2-to-v3/apis/getClientIdNamesFromNewExpr.ts
+++ b/src/transforms/v2-to-v3/apis/getClientIdNamesFromNewExpr.ts
@@ -1,4 +1,10 @@
-import { Collection, Identifier, JSCodeshift, MemberExpression, NewExpression } from "jscodeshift";
+import type {
+  Collection,
+  Identifier,
+  JSCodeshift,
+  MemberExpression,
+  NewExpression,
+} from "jscodeshift";
 
 import { DOCUMENT_CLIENT, DYNAMODB, DYNAMODB_DOCUMENT_CLIENT } from "../config";
 import { getClientNewExpression } from "../utils";

--- a/src/transforms/v2-to-v3/apis/getClientIdNamesFromTSTypeRef.ts
+++ b/src/transforms/v2-to-v3/apis/getClientIdNamesFromTSTypeRef.ts
@@ -1,4 +1,4 @@
-import { Collection, JSCodeshift } from "jscodeshift";
+import type { Collection, JSCodeshift } from "jscodeshift";
 
 export interface GetClientIdNamesFromTSTypeRefOptions {
   v2ClientName: string;

--- a/src/transforms/v2-to-v3/apis/getClientIdThisExpressions.ts
+++ b/src/transforms/v2-to-v3/apis/getClientIdThisExpressions.ts
@@ -1,5 +1,5 @@
-import { Collection, Identifier, JSCodeshift, MemberExpression } from "jscodeshift";
-import { ThisMemberExpression } from "../types";
+import type { Collection, Identifier, JSCodeshift, MemberExpression } from "jscodeshift";
+import type { ThisMemberExpression } from "../types";
 
 const thisMemberExpression = { type: "MemberExpression", object: { type: "ThisExpression" } };
 

--- a/src/transforms/v2-to-v3/apis/getClientIdentifiers.ts
+++ b/src/transforms/v2-to-v3/apis/getClientIdentifiers.ts
@@ -1,6 +1,6 @@
-import { Collection, Identifier, JSCodeshift } from "jscodeshift";
+import type { Collection, Identifier, JSCodeshift } from "jscodeshift";
 
-import { ClientIdentifier } from "../types";
+import type { ClientIdentifier } from "../types";
 import { getClientIdNamesFromNewExpr } from "./getClientIdNamesFromNewExpr";
 import { getClientIdNamesFromTSTypeRef } from "./getClientIdNamesFromTSTypeRef";
 import { getClientIdThisExpressions } from "./getClientIdThisExpressions";

--- a/src/transforms/v2-to-v3/apis/getClientIdentifiersRecord.ts
+++ b/src/transforms/v2-to-v3/apis/getClientIdentifiersRecord.ts
@@ -1,6 +1,6 @@
-import { Collection, JSCodeshift } from "jscodeshift";
+import type { Collection, JSCodeshift } from "jscodeshift";
 
-import { ClientIdentifiersRecord } from "../types";
+import type { ClientIdentifiersRecord } from "../types";
 import { getClientIdentifiers } from "./getClientIdentifiers";
 
 export interface GetClientIdentifiersRecordOptions {

--- a/src/transforms/v2-to-v3/apis/getClientWaiterCallExpression.ts
+++ b/src/transforms/v2-to-v3/apis/getClientWaiterCallExpression.ts
@@ -1,6 +1,6 @@
-import { CallExpression } from "jscodeshift";
+import type { CallExpression } from "jscodeshift";
 
-import { ClientIdentifier } from "../types";
+import type { ClientIdentifier } from "../types";
 
 export const getClientWaiterCallExpression = (
   clientId: ClientIdentifier,

--- a/src/transforms/v2-to-v3/apis/getClientWaiterStates.ts
+++ b/src/transforms/v2-to-v3/apis/getClientWaiterStates.ts
@@ -1,5 +1,5 @@
-import { Collection, JSCodeshift } from "jscodeshift";
-import { ClientIdentifier } from "../types";
+import type { Collection, JSCodeshift } from "jscodeshift";
+import type { ClientIdentifier } from "../types";
 
 export const getClientWaiterStates = (
   j: JSCodeshift,

--- a/src/transforms/v2-to-v3/apis/getS3SignedUrlApiNames.ts
+++ b/src/transforms/v2-to-v3/apis/getS3SignedUrlApiNames.ts
@@ -1,6 +1,6 @@
-import { Collection, JSCodeshift, Literal } from "jscodeshift";
+import type { Collection, JSCodeshift, Literal } from "jscodeshift";
 
-import { ClientIdentifier } from "../types";
+import type { ClientIdentifier } from "../types";
 
 export const getS3SignedUrlApiNames = (
   j: JSCodeshift,

--- a/src/transforms/v2-to-v3/apis/getWaiterConfig.ts
+++ b/src/transforms/v2-to-v3/apis/getWaiterConfig.ts
@@ -1,4 +1,4 @@
-import { ObjectExpression, ObjectProperty, Property } from "jscodeshift";
+import type { ObjectExpression, ObjectProperty, Property } from "jscodeshift";
 
 import { OBJECT_PROPERTY_TYPE_LIST } from "../config";
 

--- a/src/transforms/v2-to-v3/apis/getWaiterConfigValue.ts
+++ b/src/transforms/v2-to-v3/apis/getWaiterConfigValue.ts
@@ -1,4 +1,4 @@
-import { ObjectExpression, ObjectProperty, Property } from "jscodeshift";
+import type { ObjectExpression, ObjectProperty, Property } from "jscodeshift";
 
 import { OBJECT_PROPERTY_TYPE_LIST } from "../config";
 

--- a/src/transforms/v2-to-v3/apis/isS3CreatePresignedPostApiUsed.ts
+++ b/src/transforms/v2-to-v3/apis/isS3CreatePresignedPostApiUsed.ts
@@ -1,6 +1,6 @@
-import { Collection, JSCodeshift } from "jscodeshift";
+import type { Collection, JSCodeshift } from "jscodeshift";
 
-import { ClientIdentifier } from "../types";
+import type { ClientIdentifier } from "../types";
 
 export const isS3CreatePresignedPostApiUsed = (
   j: JSCodeshift,

--- a/src/transforms/v2-to-v3/apis/isS3GetSignedUrlApiUsed.ts
+++ b/src/transforms/v2-to-v3/apis/isS3GetSignedUrlApiUsed.ts
@@ -1,6 +1,6 @@
-import { Collection, JSCodeshift } from "jscodeshift";
+import type { Collection, JSCodeshift } from "jscodeshift";
 
-import { ClientIdentifier } from "../types";
+import type { ClientIdentifier } from "../types";
 
 export const isS3GetSignedUrlApiUsed = (
   j: JSCodeshift,

--- a/src/transforms/v2-to-v3/apis/isS3UploadApiUsed.ts
+++ b/src/transforms/v2-to-v3/apis/isS3UploadApiUsed.ts
@@ -1,6 +1,6 @@
-import { Collection, JSCodeshift } from "jscodeshift";
+import type { Collection, JSCodeshift } from "jscodeshift";
 
-import { ClientIdentifier } from "../types";
+import type { ClientIdentifier } from "../types";
 
 export const isS3UploadApiUsed = (
   j: JSCodeshift,

--- a/src/transforms/v2-to-v3/apis/removePromiseCalls.ts
+++ b/src/transforms/v2-to-v3/apis/removePromiseCalls.ts
@@ -1,6 +1,6 @@
-import { Collection, Identifier, JSCodeshift } from "jscodeshift";
+import type { Collection, Identifier, JSCodeshift } from "jscodeshift";
 
-import { ClientIdentifier } from "../types";
+import type { ClientIdentifier } from "../types";
 import { removePromiseForCallExpression } from "./removePromiseForCallExpression";
 
 export interface RemovePromiseCallsOptions {

--- a/src/transforms/v2-to-v3/apis/removePromiseForCallExpression.ts
+++ b/src/transforms/v2-to-v3/apis/removePromiseForCallExpression.ts
@@ -1,5 +1,5 @@
 import { emitWarning } from "node:process";
-import { ASTPath, CallExpression, JSCodeshift, MemberExpression } from "jscodeshift";
+import type { ASTPath, CallExpression, JSCodeshift, MemberExpression } from "jscodeshift";
 
 export const removePromiseForCallExpression = (
   j: JSCodeshift,

--- a/src/transforms/v2-to-v3/apis/renameErrorCodeWithName.ts
+++ b/src/transforms/v2-to-v3/apis/renameErrorCodeWithName.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   ASTPath,
   ArrowFunctionExpression,
   CallExpression,
@@ -8,7 +8,7 @@ import {
   TryStatement,
 } from "jscodeshift";
 
-import { ClientIdentifier } from "../types";
+import type { ClientIdentifier } from "../types";
 
 const FUNCTION_EXPRESSION_TYPES = ["ArrowFunctionExpression", "FunctionExpression"];
 

--- a/src/transforms/v2-to-v3/apis/replaceAwsEndpoint.ts
+++ b/src/transforms/v2-to-v3/apis/replaceAwsEndpoint.ts
@@ -1,4 +1,4 @@
-import { Collection, JSCodeshift } from "jscodeshift";
+import type { Collection, JSCodeshift } from "jscodeshift";
 
 export const replaceAwsEndpoint = (
   j: JSCodeshift,

--- a/src/transforms/v2-to-v3/apis/replaceAwsError.ts
+++ b/src/transforms/v2-to-v3/apis/replaceAwsError.ts
@@ -1,5 +1,5 @@
-import { Collection, JSCodeshift } from "jscodeshift";
-import { ImportType, addNamedModule } from "../modules";
+import type { Collection, JSCodeshift } from "jscodeshift";
+import { type ImportType, addNamedModule } from "../modules";
 
 export interface ReplaceAwsErrorOptions {
   v2GlobalName?: string;

--- a/src/transforms/v2-to-v3/apis/replaceAwsIdentity.ts
+++ b/src/transforms/v2-to-v3/apis/replaceAwsIdentity.ts
@@ -1,6 +1,6 @@
-import { Collection, JSCodeshift, NewExpression } from "jscodeshift";
+import type { Collection, JSCodeshift, NewExpression } from "jscodeshift";
 import { AWS_CREDENTIALS_MAP, AWS_TOKEN_MAP } from "../config";
-import { ImportType, addNamedModule } from "../modules";
+import { type ImportType, addNamedModule } from "../modules";
 
 export interface ReplaceAwsCredentialsOptions {
   v2GlobalName?: string;

--- a/src/transforms/v2-to-v3/apis/replaceS3CreatePresignedPostApi.ts
+++ b/src/transforms/v2-to-v3/apis/replaceS3CreatePresignedPostApi.ts
@@ -1,6 +1,6 @@
-import { Collection, JSCodeshift } from "jscodeshift";
+import type { Collection, JSCodeshift } from "jscodeshift";
 
-import { ClientIdentifier } from "../types";
+import type { ClientIdentifier } from "../types";
 import { getClientApiCallExpression } from "./getClientApiCallExpression";
 
 // Updates `s3.createPresignedPost(params)` API with `await createPresignedPost(s3, params)` API.

--- a/src/transforms/v2-to-v3/apis/replaceS3GetSignedUrlApi.ts
+++ b/src/transforms/v2-to-v3/apis/replaceS3GetSignedUrlApi.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   Collection,
   JSCodeshift,
   Literal,
@@ -9,7 +9,7 @@ import {
 } from "jscodeshift";
 
 import { OBJECT_PROPERTY_TYPE_LIST } from "../config";
-import { ClientIdentifier } from "../types";
+import type { ClientIdentifier } from "../types";
 import { getClientApiCallExpression } from "./getClientApiCallExpression";
 import { getCommandName } from "./getCommandName";
 

--- a/src/transforms/v2-to-v3/apis/replaceS3UploadApi.ts
+++ b/src/transforms/v2-to-v3/apis/replaceS3UploadApi.ts
@@ -1,6 +1,6 @@
-import { Collection, Identifier, JSCodeshift } from "jscodeshift";
+import type { Collection, Identifier, JSCodeshift } from "jscodeshift";
 
-import { ClientIdentifier } from "../types";
+import type { ClientIdentifier } from "../types";
 import { getClientApiCallExpression } from "./getClientApiCallExpression";
 
 // Updates `s3.upload()` API with `new Upload()` API.

--- a/src/transforms/v2-to-v3/apis/replaceWaiterApi.ts
+++ b/src/transforms/v2-to-v3/apis/replaceWaiterApi.ts
@@ -1,6 +1,6 @@
-import { Collection, JSCodeshift } from "jscodeshift";
+import type { Collection, JSCodeshift } from "jscodeshift";
 
-import { ClientIdentifier } from "../types";
+import type { ClientIdentifier } from "../types";
 import { getArgsWithoutWaiterConfig } from "./getArgsWithoutWaiterConfig";
 import { getClientWaiterCallExpression } from "./getClientWaiterCallExpression";
 import { getClientWaiterStates } from "./getClientWaiterStates";

--- a/src/transforms/v2-to-v3/aws-util/getAwsUtilCallExpression.ts
+++ b/src/transforms/v2-to-v3/aws-util/getAwsUtilCallExpression.ts
@@ -1,4 +1,4 @@
-import { Collection, JSCodeshift } from "jscodeshift";
+import type { Collection, JSCodeshift } from "jscodeshift";
 
 export interface GetAwsUtilCallExpressionOptions {
   v2GlobalName: string;

--- a/src/transforms/v2-to-v3/aws-util/replaceAwsUtilArrayFunctions.ts
+++ b/src/transforms/v2-to-v3/aws-util/replaceAwsUtilArrayFunctions.ts
@@ -1,4 +1,4 @@
-import { Collection, FunctionExpression, Identifier, JSCodeshift } from "jscodeshift";
+import type { Collection, FunctionExpression, Identifier, JSCodeshift } from "jscodeshift";
 import { getAwsUtilCallExpression } from "./getAwsUtilCallExpression";
 
 export const replaceAwsUtilArrayFunctions = (

--- a/src/transforms/v2-to-v3/aws-util/replaceAwsUtilCopy.ts
+++ b/src/transforms/v2-to-v3/aws-util/replaceAwsUtilCopy.ts
@@ -1,4 +1,4 @@
-import { Collection, JSCodeshift } from "jscodeshift";
+import type { Collection, JSCodeshift } from "jscodeshift";
 import { getAwsUtilCallExpression } from "./getAwsUtilCallExpression";
 
 export const replaceAwsUtilCopy = (

--- a/src/transforms/v2-to-v3/aws-util/replaceAwsUtilFunctions.ts
+++ b/src/transforms/v2-to-v3/aws-util/replaceAwsUtilFunctions.ts
@@ -1,4 +1,4 @@
-import { Collection, JSCodeshift } from "jscodeshift";
+import type { Collection, JSCodeshift } from "jscodeshift";
 import { replaceAwsUtilArrayFunctions } from "./replaceAwsUtilArrayFunctions";
 import { replaceAwsUtilCopy } from "./replaceAwsUtilCopy";
 

--- a/src/transforms/v2-to-v3/client-instances/getAwsGlobalConfig.ts
+++ b/src/transforms/v2-to-v3/client-instances/getAwsGlobalConfig.ts
@@ -1,4 +1,4 @@
-import { Collection, JSCodeshift, MemberExpression, ObjectExpression } from "jscodeshift";
+import type { Collection, JSCodeshift, MemberExpression, ObjectExpression } from "jscodeshift";
 
 const getUnsupportedComments = (): string[] => [
   " JS SDK v3 does not support global configuration.",

--- a/src/transforms/v2-to-v3/client-instances/getDynamoDBDocClientArgs.ts
+++ b/src/transforms/v2-to-v3/client-instances/getDynamoDBDocClientArgs.ts
@@ -1,4 +1,4 @@
-import { ASTPath, JSCodeshift, NewExpression, ObjectProperty, Property } from "jscodeshift";
+import type { ASTPath, JSCodeshift, NewExpression, ObjectProperty, Property } from "jscodeshift";
 import { OBJECT_PROPERTY_TYPE_LIST } from "../config";
 import { getDynamoDBForDocClient } from "./getDynamoDBForDocClient";
 

--- a/src/transforms/v2-to-v3/client-instances/getDynamoDBForDocClient.ts
+++ b/src/transforms/v2-to-v3/client-instances/getDynamoDBForDocClient.ts
@@ -1,4 +1,4 @@
-import { ASTPath, JSCodeshift, NewExpression, ObjectProperty, Property } from "jscodeshift";
+import type { ASTPath, JSCodeshift, NewExpression, ObjectProperty, Property } from "jscodeshift";
 
 import { DYNAMODB, OBJECT_PROPERTY_TYPE_LIST } from "../config";
 

--- a/src/transforms/v2-to-v3/client-instances/getNewClientExpression.ts
+++ b/src/transforms/v2-to-v3/client-instances/getNewClientExpression.ts
@@ -1,4 +1,4 @@
-import { ASTPath, JSCodeshift, NewExpression, ObjectExpression } from "jscodeshift";
+import type { ASTPath, JSCodeshift, NewExpression, ObjectExpression } from "jscodeshift";
 import { getObjectWithUpdatedAwsConfigKeys } from "./getObjectWithUpdatedAwsConfigKeys";
 
 export interface GetNewClientExpressionOptions {

--- a/src/transforms/v2-to-v3/client-instances/getObjectWithUpdatedAwsConfigKeys.ts
+++ b/src/transforms/v2-to-v3/client-instances/getObjectWithUpdatedAwsConfigKeys.ts
@@ -1,4 +1,10 @@
-import { Identifier, JSCodeshift, ObjectExpression, ObjectProperty, Property } from "jscodeshift";
+import type {
+  Identifier,
+  JSCodeshift,
+  ObjectExpression,
+  ObjectProperty,
+  Property,
+} from "jscodeshift";
 import { AWS_CONFIG_KEY_MAP, OBJECT_PROPERTY_TYPE_LIST } from "../config";
 
 const getRenameComment = (keyName: string, newKeyName: string) =>

--- a/src/transforms/v2-to-v3/client-instances/replaceAwsConfig.ts
+++ b/src/transforms/v2-to-v3/client-instances/replaceAwsConfig.ts
@@ -1,4 +1,4 @@
-import { Collection, JSCodeshift, ObjectExpression } from "jscodeshift";
+import type { Collection, JSCodeshift, ObjectExpression } from "jscodeshift";
 import { getObjectWithUpdatedAwsConfigKeys } from "./getObjectWithUpdatedAwsConfigKeys";
 
 export interface ReplaceAwsConfigOptions {

--- a/src/transforms/v2-to-v3/client-instances/replaceClientCreation.ts
+++ b/src/transforms/v2-to-v3/client-instances/replaceClientCreation.ts
@@ -1,4 +1,4 @@
-import { Collection, JSCodeshift, ObjectExpression } from "jscodeshift";
+import type { Collection, JSCodeshift, ObjectExpression } from "jscodeshift";
 import { getClientNewExpression } from "../utils";
 import { getNewClientExpression } from "./getNewClientExpression";
 

--- a/src/transforms/v2-to-v3/client-instances/replaceDocClientCreation.ts
+++ b/src/transforms/v2-to-v3/client-instances/replaceDocClientCreation.ts
@@ -1,4 +1,4 @@
-import { Collection, JSCodeshift } from "jscodeshift";
+import type { Collection, JSCodeshift } from "jscodeshift";
 
 import { DOCUMENT_CLIENT, DYNAMODB, DYNAMODB_DOCUMENT, DYNAMODB_DOCUMENT_CLIENT } from "../config";
 import { getClientNewExpression } from "../utils";

--- a/src/transforms/v2-to-v3/client-names/getClientMetadataRecord.ts
+++ b/src/transforms/v2-to-v3/client-names/getClientMetadataRecord.ts
@@ -1,4 +1,4 @@
-import { ClientMetadataRecord } from "../types";
+import type { ClientMetadataRecord } from "../types";
 import { getV3ClientName } from "./getV3ClientName";
 import { getV3ClientPackageName } from "./getV3ClientPackageName";
 

--- a/src/transforms/v2-to-v3/client-names/getClientNamesFromGlobal.ts
+++ b/src/transforms/v2-to-v3/client-names/getClientNamesFromGlobal.ts
@@ -1,4 +1,4 @@
-import { Collection, JSCodeshift } from "jscodeshift";
+import type { Collection, JSCodeshift } from "jscodeshift";
 
 import { CLIENT_NAMES } from "../config";
 import { getNamesFromNewExpr } from "./getNamesFromNewExpr";

--- a/src/transforms/v2-to-v3/client-names/getClientNamesRecord.ts
+++ b/src/transforms/v2-to-v3/client-names/getClientNamesRecord.ts
@@ -1,4 +1,4 @@
-import { Collection, JSCodeshift } from "jscodeshift";
+import type { Collection, JSCodeshift } from "jscodeshift";
 
 import { CLIENT_NAMES, PACKAGE_NAME } from "../config";
 import { ImportType } from "../modules";

--- a/src/transforms/v2-to-v3/client-names/getNamesFromNewExpr.ts
+++ b/src/transforms/v2-to-v3/client-names/getNamesFromNewExpr.ts
@@ -1,4 +1,4 @@
-import { Collection, Identifier, JSCodeshift, MemberExpression } from "jscodeshift";
+import type { Collection, Identifier, JSCodeshift, MemberExpression } from "jscodeshift";
 
 import { DYNAMODB_DOCUMENT_CLIENT } from "../config";
 import { getClientNewExpression } from "../utils";

--- a/src/transforms/v2-to-v3/client-names/getNamesFromTSQualifiedName.ts
+++ b/src/transforms/v2-to-v3/client-names/getNamesFromTSQualifiedName.ts
@@ -1,4 +1,4 @@
-import { Collection, Identifier, JSCodeshift } from "jscodeshift";
+import type { Collection, Identifier, JSCodeshift } from "jscodeshift";
 
 export const getNamesFromTSQualifiedName = (
   j: JSCodeshift,

--- a/src/transforms/v2-to-v3/modules/addClientModules.ts
+++ b/src/transforms/v2-to-v3/modules/addClientModules.ts
@@ -1,4 +1,4 @@
-import { Collection, JSCodeshift } from "jscodeshift";
+import type { Collection, JSCodeshift } from "jscodeshift";
 
 import {
   getClientWaiterStates,
@@ -21,7 +21,7 @@ import { addNamedModule } from "./addNamedModule";
 import { getClientTSTypeRefCount } from "./getClientTSTypeRefCount";
 import { getNewExpressionCount } from "./getNewExpressionCount";
 
-import { ClientModulesOptions } from "./types";
+import type { ClientModulesOptions } from "./types";
 
 export const addClientModules = (
   j: JSCodeshift,

--- a/src/transforms/v2-to-v3/modules/addNamedModule.ts
+++ b/src/transforms/v2-to-v3/modules/addNamedModule.ts
@@ -1,9 +1,9 @@
-import { Collection, JSCodeshift } from "jscodeshift";
+import type { Collection, JSCodeshift } from "jscodeshift";
 
 import * as importEqualsModule from "./importEqualsModule";
 import * as importModule from "./importModule";
 import * as requireModule from "./requireModule";
-import { ImportType, ModulesOptions } from "./types";
+import { ImportType, type ModulesOptions } from "./types";
 
 export const addNamedModule = (
   j: JSCodeshift,

--- a/src/transforms/v2-to-v3/modules/getClientTSTypeRefCount.ts
+++ b/src/transforms/v2-to-v3/modules/getClientTSTypeRefCount.ts
@@ -1,7 +1,7 @@
-import { Collection, JSCodeshift } from "jscodeshift";
+import type { Collection, JSCodeshift } from "jscodeshift";
 
 import { getTSQualifiedNameFromClientName } from "../ts-type";
-import { ClientModulesOptions } from "./types";
+import type { ClientModulesOptions } from "./types";
 
 export const getClientTSTypeRefCount = (
   j: JSCodeshift,

--- a/src/transforms/v2-to-v3/modules/getGlobalNameFromModule.ts
+++ b/src/transforms/v2-to-v3/modules/getGlobalNameFromModule.ts
@@ -1,4 +1,4 @@
-import { Collection, Identifier, JSCodeshift } from "jscodeshift";
+import type { Collection, Identifier, JSCodeshift } from "jscodeshift";
 
 import { PACKAGE_NAME } from "../config";
 import { getImportSpecifiers as getImportEqualsSpecifiers } from "../modules/importEqualsModule";

--- a/src/transforms/v2-to-v3/modules/getImportType.ts
+++ b/src/transforms/v2-to-v3/modules/getImportType.ts
@@ -1,4 +1,4 @@
-import { Collection, JSCodeshift } from "jscodeshift";
+import type { Collection, JSCodeshift } from "jscodeshift";
 import { hasImport } from "./hasImport";
 import { hasImportEquals } from "./hasImportEquals";
 import { hasRequire } from "./hasRequire";

--- a/src/transforms/v2-to-v3/modules/getNewExpressionCount.ts
+++ b/src/transforms/v2-to-v3/modules/getNewExpressionCount.ts
@@ -1,8 +1,8 @@
-import { Collection, JSCodeshift } from "jscodeshift";
+import type { Collection, JSCodeshift } from "jscodeshift";
 
 import { DOCUMENT_CLIENT, DYNAMODB, DYNAMODB_DOCUMENT_CLIENT } from "../config";
 import { getClientNewExpression } from "../utils";
-import { ClientModulesOptions } from "./types";
+import type { ClientModulesOptions } from "./types";
 
 export const getNewExpressionCount = (
   j: JSCodeshift,

--- a/src/transforms/v2-to-v3/modules/getRequireDeclaratorsWithObjectPattern.ts
+++ b/src/transforms/v2-to-v3/modules/getRequireDeclaratorsWithObjectPattern.ts
@@ -1,4 +1,4 @@
-import { Collection, JSCodeshift, ObjectProperty, Property } from "jscodeshift";
+import type { Collection, JSCodeshift, ObjectProperty, Property } from "jscodeshift";
 
 import { OBJECT_PROPERTY_TYPE_LIST } from "../config";
 import { getRequireDeclarators } from "./requireModule";

--- a/src/transforms/v2-to-v3/modules/getRequireDeclaratorsWithProperty.ts
+++ b/src/transforms/v2-to-v3/modules/getRequireDeclaratorsWithProperty.ts
@@ -1,4 +1,4 @@
-import { Collection, Identifier, JSCodeshift } from "jscodeshift";
+import type { Collection, Identifier, JSCodeshift } from "jscodeshift";
 import { getRequireDeclarators } from "./requireModule";
 
 export interface GetRequireDeclaratorsWithPropertyOptions {

--- a/src/transforms/v2-to-v3/modules/hasImport.ts
+++ b/src/transforms/v2-to-v3/modules/hasImport.ts
@@ -1,4 +1,4 @@
-import { Collection, JSCodeshift } from "jscodeshift";
+import type { Collection, JSCodeshift } from "jscodeshift";
 import { getImportDeclarations } from "./importModule";
 
 export const hasImport = (j: JSCodeshift, source: Collection<unknown>) =>

--- a/src/transforms/v2-to-v3/modules/hasImportEquals.ts
+++ b/src/transforms/v2-to-v3/modules/hasImportEquals.ts
@@ -1,4 +1,4 @@
-import { Collection, JSCodeshift } from "jscodeshift";
+import type { Collection, JSCodeshift } from "jscodeshift";
 import { getImportEqualsDeclarations } from "./importEqualsModule";
 
 export const hasImportEquals = (j: JSCodeshift, source: Collection<unknown>) =>

--- a/src/transforms/v2-to-v3/modules/hasRequire.ts
+++ b/src/transforms/v2-to-v3/modules/hasRequire.ts
@@ -1,4 +1,4 @@
-import { Collection, JSCodeshift } from "jscodeshift";
+import type { Collection, JSCodeshift } from "jscodeshift";
 import { getRequireDeclarators } from "./requireModule";
 
 export const hasRequire = (j: JSCodeshift, source: Collection<unknown>) =>

--- a/src/transforms/v2-to-v3/modules/importEqualsModule/addDefaultModule.ts
+++ b/src/transforms/v2-to-v3/modules/importEqualsModule/addDefaultModule.ts
@@ -1,4 +1,4 @@
-import { Collection, JSCodeshift } from "jscodeshift";
+import type { Collection, JSCodeshift } from "jscodeshift";
 
 import { getImportEqualsDeclarations, getImportSpecifiers } from "../importEqualsModule";
 import { getDefaultName } from "./getDefaultName";

--- a/src/transforms/v2-to-v3/modules/importEqualsModule/addNamedModule.ts
+++ b/src/transforms/v2-to-v3/modules/importEqualsModule/addNamedModule.ts
@@ -1,6 +1,6 @@
-import { Collection, JSCodeshift } from "jscodeshift";
+import type { Collection, JSCodeshift } from "jscodeshift";
 
-import { ModulesOptions } from "../types";
+import type { ModulesOptions } from "../types";
 import { addDefaultModule } from "./addDefaultModule";
 import { getDefaultName } from "./getDefaultName";
 import { getImportEqualsDeclarations } from "./getImportEqualsDeclarations";

--- a/src/transforms/v2-to-v3/modules/importEqualsModule/getImportEqualsDeclarations.ts
+++ b/src/transforms/v2-to-v3/modules/importEqualsModule/getImportEqualsDeclarations.ts
@@ -1,4 +1,9 @@
-import { Collection, JSCodeshift, StringLiteral, TSExternalModuleReference } from "jscodeshift";
+import type {
+  Collection,
+  JSCodeshift,
+  StringLiteral,
+  TSExternalModuleReference,
+} from "jscodeshift";
 import { PACKAGE_NAME } from "../../config";
 
 export const getImportEqualsDeclarations = (

--- a/src/transforms/v2-to-v3/modules/importEqualsModule/getImportSpecifiers.ts
+++ b/src/transforms/v2-to-v3/modules/importEqualsModule/getImportSpecifiers.ts
@@ -1,5 +1,5 @@
-import { Collection, JSCodeshift } from "jscodeshift";
-import { ImportSpecifierType } from "../types";
+import type { Collection, JSCodeshift } from "jscodeshift";
+import type { ImportSpecifierType } from "../types";
 import { getImportEqualsDeclarations } from "./getImportEqualsDeclarations";
 
 export const getImportSpecifiers = (

--- a/src/transforms/v2-to-v3/modules/importEqualsModule/removeImportEquals.ts
+++ b/src/transforms/v2-to-v3/modules/importEqualsModule/removeImportEquals.ts
@@ -1,4 +1,4 @@
-import { Collection, JSCodeshift } from "jscodeshift";
+import type { Collection, JSCodeshift } from "jscodeshift";
 import { removeDeclaration } from "../removeDeclaration";
 import { getImportEqualsDeclarations } from "./getImportEqualsDeclarations";
 

--- a/src/transforms/v2-to-v3/modules/importModule/addNamedModule.ts
+++ b/src/transforms/v2-to-v3/modules/importModule/addNamedModule.ts
@@ -1,8 +1,8 @@
-import { Collection, JSCodeshift } from "jscodeshift";
+import type { Collection, JSCodeshift } from "jscodeshift";
 
 import { getImportDeclarations, getImportSpecifiers } from "../importModule";
 import { importSpecifierCompareFn } from "../importSpecifierCompareFn";
-import { ModulesOptions } from "../types";
+import type { ModulesOptions } from "../types";
 
 export const addNamedModule = (
   j: JSCodeshift,

--- a/src/transforms/v2-to-v3/modules/importModule/getImportDeclarations.ts
+++ b/src/transforms/v2-to-v3/modules/importModule/getImportDeclarations.ts
@@ -1,4 +1,4 @@
-import { Collection, JSCodeshift } from "jscodeshift";
+import type { Collection, JSCodeshift } from "jscodeshift";
 import { PACKAGE_NAME } from "../../config";
 
 export const getImportDeclarations = (j: JSCodeshift, source: Collection<unknown>, path?: string) =>

--- a/src/transforms/v2-to-v3/modules/importModule/getImportSpecifiers.ts
+++ b/src/transforms/v2-to-v3/modules/importModule/getImportSpecifiers.ts
@@ -1,5 +1,5 @@
-import { Collection, JSCodeshift } from "jscodeshift";
-import { ImportSpecifierType } from "../types";
+import type { Collection, JSCodeshift } from "jscodeshift";
+import type { ImportSpecifierType } from "../types";
 import { getImportDeclarations } from "./getImportDeclarations";
 
 export const getImportSpecifiers = (

--- a/src/transforms/v2-to-v3/modules/importModule/removeImport.ts
+++ b/src/transforms/v2-to-v3/modules/importModule/removeImport.ts
@@ -1,4 +1,4 @@
-import { Collection, JSCodeshift } from "jscodeshift";
+import type { Collection, JSCodeshift } from "jscodeshift";
 import { removeDeclaration } from "../removeDeclaration";
 import { getImportDeclarations } from "./getImportDeclarations";
 

--- a/src/transforms/v2-to-v3/modules/importSpecifierCompareFn.ts
+++ b/src/transforms/v2-to-v3/modules/importSpecifierCompareFn.ts
@@ -1,4 +1,8 @@
-import { ImportDefaultSpecifier, ImportNamespaceSpecifier, ImportSpecifier } from "jscodeshift";
+import type {
+  ImportDefaultSpecifier,
+  ImportNamespaceSpecifier,
+  ImportSpecifier,
+} from "jscodeshift";
 
 export const importSpecifierCompareFn = (
   specifier1: ImportSpecifier | ImportDefaultSpecifier | ImportNamespaceSpecifier,

--- a/src/transforms/v2-to-v3/modules/objectPatternPropertyCompareFn.ts
+++ b/src/transforms/v2-to-v3/modules/objectPatternPropertyCompareFn.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   ObjectProperty,
   Property,
   PropertyPattern,

--- a/src/transforms/v2-to-v3/modules/removeDeclaration.ts
+++ b/src/transforms/v2-to-v3/modules/removeDeclaration.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   ASTPath,
   Collection,
   ImportDeclaration,

--- a/src/transforms/v2-to-v3/modules/removeModules.ts
+++ b/src/transforms/v2-to-v3/modules/removeModules.ts
@@ -1,4 +1,4 @@
-import { Collection, JSCodeshift } from "jscodeshift";
+import type { Collection, JSCodeshift } from "jscodeshift";
 import { removeImportEquals } from "./importEqualsModule";
 import { removeImport } from "./importModule";
 import { removeRequire } from "./requireModule";

--- a/src/transforms/v2-to-v3/modules/replaceDeepImport.ts
+++ b/src/transforms/v2-to-v3/modules/replaceDeepImport.ts
@@ -1,4 +1,4 @@
-import { Collection, JSCodeshift } from "jscodeshift";
+import type { Collection, JSCodeshift } from "jscodeshift";
 
 export interface ReplaceDeepImportOptions {
   fromPath: string;

--- a/src/transforms/v2-to-v3/modules/requireModule/addNamedModule.ts
+++ b/src/transforms/v2-to-v3/modules/requireModule/addNamedModule.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   Collection,
   JSCodeshift,
   Literal,
@@ -11,7 +11,7 @@ import {
 import { OBJECT_PROPERTY_TYPE_LIST, PACKAGE_NAME, STRING_LITERAL_TYPE_LIST } from "../../config";
 import { objectPatternPropertyCompareFn } from "../objectPatternPropertyCompareFn";
 import { getRequireDeclarators } from "../requireModule";
-import { ModulesOptions } from "../types";
+import type { ModulesOptions } from "../types";
 
 export const addNamedModule = (
   j: JSCodeshift,

--- a/src/transforms/v2-to-v3/modules/requireModule/getImportSpecifiers.ts
+++ b/src/transforms/v2-to-v3/modules/requireModule/getImportSpecifiers.ts
@@ -1,6 +1,6 @@
-import { Collection, Identifier, JSCodeshift, ObjectProperty, Property } from "jscodeshift";
+import type { Collection, Identifier, JSCodeshift, ObjectProperty, Property } from "jscodeshift";
 import { OBJECT_PROPERTY_TYPE_LIST } from "../../config";
-import { ImportSpecifierType } from "../types";
+import type { ImportSpecifierType } from "../types";
 import { getRequireDeclarators } from "./getRequireDeclarators";
 
 const getImportSpecifiersFromObjectPattern = (properties: (Property | ObjectProperty)[]) => {

--- a/src/transforms/v2-to-v3/modules/requireModule/getRequireDeclarators.ts
+++ b/src/transforms/v2-to-v3/modules/requireModule/getRequireDeclarators.ts
@@ -1,4 +1,10 @@
-import { CallExpression, Collection, JSCodeshift, Literal, VariableDeclarator } from "jscodeshift";
+import type {
+  CallExpression,
+  Collection,
+  JSCodeshift,
+  Literal,
+  VariableDeclarator,
+} from "jscodeshift";
 import { PACKAGE_NAME } from "../../config";
 
 const isValidRequireCallExpression = (callExpression: CallExpression, path?: string) => {

--- a/src/transforms/v2-to-v3/modules/requireModule/removeRequire.ts
+++ b/src/transforms/v2-to-v3/modules/requireModule/removeRequire.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   CallExpression,
   Collection,
   Identifier,
@@ -12,7 +12,7 @@ import {
 } from "jscodeshift";
 import { OBJECT_PROPERTY_TYPE_LIST, STRING_LITERAL_TYPE_LIST } from "../../config";
 import { removeDeclaration } from "../removeDeclaration";
-import { ImportSpecifierType } from "../types";
+import type { ImportSpecifierType } from "../types";
 import { getRequireDeclarators } from "./getRequireDeclarators";
 
 // ToDo: create utility to share with requireModule/addNamedModule

--- a/src/transforms/v2-to-v3/modules/types.ts
+++ b/src/transforms/v2-to-v3/modules/types.ts
@@ -1,4 +1,4 @@
-import { ClientIdentifier } from "../types";
+import type { ClientIdentifier } from "../types";
 
 export interface ClientModulesOptions {
   v2ClientName: string;

--- a/src/transforms/v2-to-v3/transformer.ts
+++ b/src/transforms/v2-to-v3/transformer.ts
@@ -1,4 +1,4 @@
-import { API, FileInfo } from "jscodeshift";
+import type { API, FileInfo } from "jscodeshift";
 
 import {
   addEmptyObjectForUndefined,

--- a/src/transforms/v2-to-v3/ts-type/getClientTypeNames.ts
+++ b/src/transforms/v2-to-v3/ts-type/getClientTypeNames.ts
@@ -1,9 +1,18 @@
-import { Collection, Identifier, JSCodeshift, TSQualifiedName, TSTypeReference } from "jscodeshift";
+import type {
+  Collection,
+  Identifier,
+  JSCodeshift,
+  TSQualifiedName,
+  TSTypeReference,
+} from "jscodeshift";
 
-import { ImportSpecifierType } from "../modules";
+import type { ImportSpecifierType } from "../modules";
 import { getImportSpecifiers } from "../modules/importModule";
 import { getClientDeepImportPath } from "../utils";
-import { DeepPartial, getTSQualifiedNameFromClientName } from "./getTSQualifiedNameFromClientName";
+import {
+  type DeepPartial,
+  getTSQualifiedNameFromClientName,
+} from "./getTSQualifiedNameFromClientName";
 
 export interface GetClientTypeNamesOptions {
   v2ClientName: string;

--- a/src/transforms/v2-to-v3/ts-type/getTSQualifiedNameFromClientName.ts
+++ b/src/transforms/v2-to-v3/ts-type/getTSQualifiedNameFromClientName.ts
@@ -1,4 +1,4 @@
-import { Identifier, TSQualifiedName } from "jscodeshift";
+import type { Identifier, TSQualifiedName } from "jscodeshift";
 
 export type DeepPartial<T> = Partial<{ [P in keyof T]: DeepPartial<T[P]> }>;
 

--- a/src/transforms/v2-to-v3/ts-type/getTypeForString.ts
+++ b/src/transforms/v2-to-v3/ts-type/getTypeForString.ts
@@ -1,4 +1,4 @@
-import { JSCodeshift, TSType } from "jscodeshift";
+import type { JSCodeshift, TSType } from "jscodeshift";
 
 const arrayRegex = /^Array<(.*)>$/;
 const recordRegex = /^Record<string, (.*)>$/;

--- a/src/transforms/v2-to-v3/ts-type/getV3ClientType.ts
+++ b/src/transforms/v2-to-v3/ts-type/getV3ClientType.ts
@@ -1,4 +1,4 @@
-import { JSCodeshift, TSType } from "jscodeshift";
+import type { JSCodeshift, TSType } from "jscodeshift";
 
 import { CLIENT_TYPES_MAP } from "../config";
 import { CLIENT_REQ_RESP_TYPES_MAP } from "../config/CLIENT_REQ_RESP_TYPES_MAP";

--- a/src/transforms/v2-to-v3/ts-type/getV3ClientTypes.ts
+++ b/src/transforms/v2-to-v3/ts-type/getV3ClientTypes.ts
@@ -1,7 +1,7 @@
-import { Collection, JSCodeshift } from "jscodeshift";
+import type { Collection, JSCodeshift } from "jscodeshift";
 
 import { CLIENT_REQ_RESP_TYPES_MAP, CLIENT_TYPES_MAP } from "../config";
-import { GetClientTypeNamesOptions, getClientTypeNames } from "./getClientTypeNames";
+import { type GetClientTypeNamesOptions, getClientTypeNames } from "./getClientTypeNames";
 
 const arrayBracketRegex = /<([\w]+)>/g;
 const recordBracketRegex = /<string, ([\w]+)>/g;

--- a/src/transforms/v2-to-v3/ts-type/removeTypesFromTSQualifiedName.ts
+++ b/src/transforms/v2-to-v3/ts-type/removeTypesFromTSQualifiedName.ts
@@ -1,4 +1,4 @@
-import { Collection, JSCodeshift } from "jscodeshift";
+import type { Collection, JSCodeshift } from "jscodeshift";
 
 export const removeTypesFromTSQualifiedName = (
   j: JSCodeshift,

--- a/src/transforms/v2-to-v3/ts-type/replaceTSTypeReference.ts
+++ b/src/transforms/v2-to-v3/ts-type/replaceTSTypeReference.ts
@@ -1,4 +1,10 @@
-import { Collection, Identifier, JSCodeshift, TSQualifiedName, TSTypeReference } from "jscodeshift";
+import type {
+  Collection,
+  Identifier,
+  JSCodeshift,
+  TSQualifiedName,
+  TSTypeReference,
+} from "jscodeshift";
 
 import { DOCUMENT_CLIENT, DYNAMODB, DYNAMODB_DOCUMENT, DYNAMODB_DOCUMENT_CLIENT } from "../config";
 import { getClientTypeNames } from "./getClientTypeNames";

--- a/src/transforms/v2-to-v3/types.ts
+++ b/src/transforms/v2-to-v3/types.ts
@@ -1,4 +1,4 @@
-import { Identifier, ThisExpression } from "jscodeshift";
+import type { Identifier, ThisExpression } from "jscodeshift";
 
 export type ClientMetadataRecord = Record<string, ClientMetadata>;
 

--- a/src/transforms/v2-to-v3/utils/getClientNewExpression.ts
+++ b/src/transforms/v2-to-v3/utils/getClientNewExpression.ts
@@ -1,4 +1,4 @@
-import { NewExpression } from "jscodeshift";
+import type { NewExpression } from "jscodeshift";
 
 export interface ClientNewExpressionOptions {
   v2ClientLocalName?: string;

--- a/src/transforms/v2-to-v3/utils/getMostUsedStringLiteralQuote.ts
+++ b/src/transforms/v2-to-v3/utils/getMostUsedStringLiteralQuote.ts
@@ -1,4 +1,4 @@
-import { Collection, JSCodeshift } from "jscodeshift";
+import type { Collection, JSCodeshift } from "jscodeshift";
 
 export enum StringLiteralQuoteType {
   SINGLE = "single",

--- a/src/transforms/v2-to-v3/utils/isTrailingCommaUsed.ts
+++ b/src/transforms/v2-to-v3/utils/isTrailingCommaUsed.ts
@@ -1,4 +1,4 @@
-import { Collection, JSCodeshift } from "jscodeshift";
+import type { Collection, JSCodeshift } from "jscodeshift";
 
 export const isTrailingCommaUsed = (j: JSCodeshift, source: Collection<unknown>) => {
   for (const node of source.find(j.ObjectExpression).nodes()) {

--- a/src/utils/getHelpParagraph.ts
+++ b/src/utils/getHelpParagraph.ts
@@ -1,4 +1,4 @@
-import { AwsSdkJsCodemodTransform } from "../transforms";
+import type { AwsSdkJsCodemodTransform } from "../transforms";
 import { getTransformDescription } from "./getTransformDescription";
 
 const separator = "-".repeat(95);

--- a/src/utils/getTransformDescription.ts
+++ b/src/utils/getTransformDescription.ts
@@ -1,4 +1,4 @@
-import { AwsSdkJsCodemodTransform } from "../transforms";
+import type { AwsSdkJsCodemodTransform } from "../transforms";
 
 const getWrappedBlocks = (sentence: string, blockLength: number): string[] => {
   const words = sentence.split(" ");

--- a/src/utils/getTransforms.ts
+++ b/src/utils/getTransforms.ts
@@ -1,7 +1,7 @@
 import { readdirSync } from "node:fs";
 import { join } from "node:path";
 
-import { AwsSdkJsCodemodTransform } from "../transforms";
+import type { AwsSdkJsCodemodTransform } from "../transforms";
 
 export const getTransforms = () =>
   readdirSync(join(__dirname, "..", "transforms"), { withFileTypes: true })


### PR DESCRIPTION
### Issue

* Biome rule: https://biomejs.dev/linter/rules/use-import-type/
* TypeScript docs: https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-8.html#type-only-imports-and-export

### Description

Use TypeScript type import for types

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
