### PR TITLE
Use `.flatMap()` instead of `.map().flat()`

### DIFF
--- a/.changeset/tidy-moles-join.md
+++ b/.changeset/tidy-moles-join.md
@@ -1,0 +1,5 @@
+---
+"aws-sdk-js-codemod": patch
+---
+
+Use `.flatMap()` instead of `.map().flat()`

--- a/biome.json
+++ b/biome.json
@@ -14,7 +14,6 @@
       "recommended": true,
       "complexity": {
         "noForEach": "off",
-        "useFlatMap": "off",
         "useOptionalChain": "off"
       },
       "correctness": {

--- a/src/transforms/v2-to-v3/client-names/getClientNamesFromDeepImport.ts
+++ b/src/transforms/v2-to-v3/client-names/getClientNamesFromDeepImport.ts
@@ -4,7 +4,7 @@ const DEEP_IMPORT_PATH_REGEXP = new RegExp(`${PACKAGE_NAME}/clients/([\\w]*)`, "
 
 export const getClientNamesFromDeepImport = (fileSource: string) => {
   const clientsFromDeepImportPath = new Set(
-    [...fileSource.matchAll(DEEP_IMPORT_PATH_REGEXP)].map((regExpMatch) => regExpMatch[1]).flat()
+    [...fileSource.matchAll(DEEP_IMPORT_PATH_REGEXP)].flatMap((regExpMatch) => regExpMatch[1])
   );
 
   return CLIENT_NAMES.filter((clientName) =>

--- a/src/transforms/v2-to-v3/ts-type/getV3ClientTypes.ts
+++ b/src/transforms/v2-to-v3/ts-type/getV3ClientTypes.ts
@@ -37,7 +37,7 @@ export const getV3ClientTypes = (
       const typesFromString = getTypesFromString(clientTypesMap[clientTypeName]);
       return typesFromString.some((type) => !nativeTypes.includes(type));
     })
-    .map((clientTypeName) => {
+    .flatMap((clientTypeName) => {
       if (clientTypeName === "ClientConfiguration") {
         return clientTypesMap[clientTypeName];
       }
@@ -51,6 +51,5 @@ export const getV3ClientTypes = (
       }
 
       return clientTypeName;
-    })
-    .flat();
+    });
 };


### PR DESCRIPTION
### Issue

* Biome rule https://biomejs.dev/linter/rules/use-flat-map/
* MDN https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flatMap

### Description

Use `.flatMap()` instead of `.map().flat()`

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
