### PR TITLE
Use optional chain instead of chained logical expressions

### DIFF
--- a/.changeset/nasty-peaches-complain.md
+++ b/.changeset/nasty-peaches-complain.md
@@ -1,0 +1,5 @@
+---
+"aws-sdk-js-codemod": patch
+---
+
+Use optional chain instead of chained logical expressions

--- a/biome.json
+++ b/biome.json
@@ -13,8 +13,7 @@
     "rules": {
       "recommended": true,
       "complexity": {
-        "noForEach": "off",
-        "useOptionalChain": "off"
+        "noForEach": "off"
       },
       "correctness": {
         "noNewSymbol": "error",

--- a/src/transforms/v2-to-v3/utils/isTrailingCommaUsed.ts
+++ b/src/transforms/v2-to-v3/utils/isTrailingCommaUsed.ts
@@ -3,7 +3,7 @@ import type { Collection, JSCodeshift } from "jscodeshift";
 export const isTrailingCommaUsed = (j: JSCodeshift, source: Collection<unknown>) => {
   for (const node of source.find(j.ObjectExpression).nodes()) {
     // @ts-ignore Property 'extra' does not exist on type 'ObjectExpression'.
-    if (node.extra && node.extra.trailingComma) {
+    if (node.extra?.trailingComma) {
       return true;
     }
   }


### PR DESCRIPTION
### Issue

* Biome rule https://biomejs.dev/linter/rules/use-optional-chain/
* MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining

### Description

Use optional chain instead of chained logical expressions

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
