### PR TITLE
Prefer template literals over string concatenation

### DIFF
--- a/.changeset/shaggy-rocks-melt.md
+++ b/.changeset/shaggy-rocks-melt.md
@@ -1,0 +1,5 @@
+---
+"aws-sdk-js-codemod": patch
+---
+
+Prefer template literals over string concatenation

--- a/biome.json
+++ b/biome.json
@@ -26,8 +26,7 @@
         "useConsistentArrayType": {
           "level": "error",
           "options": { "syntax": "shorthand" }
-        },
-        "useTemplate": "off"
+        }
       },
       "suspicious": {
         "noEmptyBlockStatements": "error"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -58,6 +58,7 @@ try {
   ({ options, positionalArguments } = parser.parse());
   if (positionalArguments.length === 0 && !options.stdin) {
     process.stderr.write(
+      // biome-ignore lint/style/useTemplate: This is a multiline string
       "Error: You have to provide at least one file/directory to transform." +
         "\n\n---\n\n" +
         parser.getHelpText()

--- a/src/transforms/v2-to-v3/apis/removePromiseForCallExpression.ts
+++ b/src/transforms/v2-to-v3/apis/removePromiseForCallExpression.ts
@@ -32,6 +32,7 @@ export const removePromiseForCallExpression = (
     }
     default: {
       emitWarning(
+        // biome-ignore lint/style/useTemplate: This is a multiline string
         `Removal of .promise() not implemented for parentPath: ${callExpression.parentPath.value.type}\n` +
           `Code processed: ${j(callExpression.parentPath).toSource()}\n\n` +
           "Please report your use case on https://github.com/aws/aws-sdk-js-codemod\n"

--- a/src/utils/getTransformDescription.ts
+++ b/src/utils/getTransformDescription.ts
@@ -15,7 +15,7 @@ const getWrappedBlocks = (sentence: string, blockLength: number): string[] => {
     }
 
     // add the word to the current block
-    currentBlock += word + " ";
+    currentBlock += `${word} `;
   }
 
   // add the final block to the list of blocks


### PR DESCRIPTION
### Issue

Biome rule: https://biomejs.dev/linter/rules/use-template/

### Description

Prefer template literals over string concatenation

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
