### PR TITLE
Disallow template literals if interpolation and special-character handling are not needed

### DIFF
--- a/.changeset/hot-geese-deliver.md
+++ b/.changeset/hot-geese-deliver.md
@@ -1,0 +1,5 @@
+---
+"aws-sdk-js-codemod": patch
+---
+
+Disallow template literals if interpolation and special-character handling are not needed

--- a/biome.json
+++ b/biome.json
@@ -22,7 +22,6 @@
       },
       "style": {
         "noNamespace": "error",
-        "noUnusedTemplateLiteral": "off",
         "useConsistentArrayType": {
           "level": "error",
           "options": { "syntax": "shorthand" }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -40,14 +40,14 @@ if (args[2] === "--help" || args[2] === "-h") {
 }
 
 const disclaimerLines = [
-  `╔════════════════════════════════════════════════════════╗`,
-  `║ Please review the code change thoroughly for required  ║`,
-  `║ functionality before deploying it to production.       ║`,
-  `║                                                        ║`,
-  `║ If the transformation is not complete or is incorrect, ║`,
-  `║ please report the issue on GitHub.                     ║`,
-  `╚════════════════════════════════════════════════════════╝`,
-  ``,
+  "╔════════════════════════════════════════════════════════╗",
+  "║ Please review the code change thoroughly for required  ║",
+  "║ functionality before deploying it to production.       ║",
+  "║                                                        ║",
+  "║ If the transformation is not complete or is incorrect, ║",
+  "║ please report the issue on GitHub.                     ║",
+  "╚════════════════════════════════════════════════════════╝",
+  "",
 ];
 
 const parser = getJsCodeshiftParser();

--- a/src/transforms/v2-to-v3/client-instances/getObjectWithUpdatedAwsConfigKeys.ts
+++ b/src/transforms/v2-to-v3/client-instances/getObjectWithUpdatedAwsConfigKeys.ts
@@ -14,8 +14,8 @@ const getUnsuppportedComment = (keyName: string) =>
   ` The key ${keyName} is no longer supported in v3, and can be removed.`;
 
 const getCodemodUnsuppportedComments = (keyName: string) => [
-  ` The transformation for ${keyName} is not implemented.`,
-  ` Refer to UPGRADING.md on aws-sdk-js-v3 for changes needed.`,
+  " The transformation for ${keyName} is not implemented.",
+  " Refer to UPGRADING.md on aws-sdk-js-v3 for changes needed.",
   ` Please create/upvote feature request on aws-sdk-js-codemod for ${keyName}.`,
 ];
 

--- a/src/transforms/v2-to-v3/client-instances/getObjectWithUpdatedAwsConfigKeys.ts
+++ b/src/transforms/v2-to-v3/client-instances/getObjectWithUpdatedAwsConfigKeys.ts
@@ -14,7 +14,7 @@ const getUnsuppportedComment = (keyName: string) =>
   ` The key ${keyName} is no longer supported in v3, and can be removed.`;
 
 const getCodemodUnsuppportedComments = (keyName: string) => [
-  " The transformation for ${keyName} is not implemented.",
+  ` The transformation for ${keyName} is not implemented.`,
   " Refer to UPGRADING.md on aws-sdk-js-v3 for changes needed.",
   ` Please create/upvote feature request on aws-sdk-js-codemod for ${keyName}.`,
 ];

--- a/src/transforms/v2-to-v3/config/AWS_CONFIG_KEY_MAP.ts
+++ b/src/transforms/v2-to-v3/config/AWS_CONFIG_KEY_MAP.ts
@@ -9,7 +9,7 @@ export interface AwsConfigKeyStatus {
  */
 export const AWS_CONFIG_KEY_MAP: Record<string, AwsConfigKeyStatus> = {
   apiVersion: {
-    deprecationMessage: `The client uses the "latest" apiVersion.`,
+    deprecationMessage: 'The client uses the "latest" apiVersion.',
   },
   computeChecksums: {
     deprecationMessage: "Applicable commands of S3 will automatically compute the MD5 checksums.",

--- a/src/transforms/v2-to-v3/config/AWS_CONFIG_KEY_MAP.ts
+++ b/src/transforms/v2-to-v3/config/AWS_CONFIG_KEY_MAP.ts
@@ -65,8 +65,8 @@ export const AWS_CONFIG_KEY_MAP: Record<string, AwsConfigKeyStatus> = {
     newKeyName: "useArnRegion",
   },
   s3UsEast1RegionalEndpoint: {
-    description: `S3 client will always use regional endpoint if region is set to "us-east-1".`,
-    deprecationMessage: `Set region to "aws-global" to send requests to S3 global endpoint.`,
+    description: "S3 client will always use regional endpoint if region is set to 'us-east-1'.",
+    deprecationMessage: "Set region to 'aws-global' to send requests to S3 global endpoint.",
   },
   signatureCache: {
     deprecationMessage: "SDK always caches the hashed signing keys.",
@@ -78,8 +78,8 @@ export const AWS_CONFIG_KEY_MAP: Record<string, AwsConfigKeyStatus> = {
     newKeyName: "tls",
   },
   stsRegionalEndpoints: {
-    description: `STS client will always use regional endpoints if set to a specific region.`,
-    deprecationMessage: `Set region to "aws-global" to send requests to STS global endpoint.`,
+    description: "STS client will always use regional endpoints if set to a specific region.",
+    deprecationMessage: "Set region to 'aws-global' to send requests to STS global endpoint.",
   },
   useAccelerateEndpoint: {},
   useDualstackEndpoint: {},

--- a/src/transforms/v2-to-v3/config/AWS_CONFIG_KEY_MAP.ts
+++ b/src/transforms/v2-to-v3/config/AWS_CONFIG_KEY_MAP.ts
@@ -65,8 +65,8 @@ export const AWS_CONFIG_KEY_MAP: Record<string, AwsConfigKeyStatus> = {
     newKeyName: "useArnRegion",
   },
   s3UsEast1RegionalEndpoint: {
-    description: "S3 client will always use regional endpoint if region is set to 'us-east-1'.",
-    deprecationMessage: "Set region to 'aws-global' to send requests to S3 global endpoint.",
+    description: 'S3 client will always use regional endpoint if region is set to "us-east-1".',
+    deprecationMessage: 'Set region to "aws-global" to send requests to S3 global endpoint.',
   },
   signatureCache: {
     deprecationMessage: "SDK always caches the hashed signing keys.",
@@ -79,7 +79,7 @@ export const AWS_CONFIG_KEY_MAP: Record<string, AwsConfigKeyStatus> = {
   },
   stsRegionalEndpoints: {
     description: "STS client will always use regional endpoints if set to a specific region.",
-    deprecationMessage: "Set region to 'aws-global' to send requests to STS global endpoint.",
+    deprecationMessage: 'Set region to "aws-global" to send requests to STS global endpoint.',
   },
   useAccelerateEndpoint: {},
   useDualstackEndpoint: {},

--- a/src/transforms/v2-to-v3/transformer.spec.ts
+++ b/src/transforms/v2-to-v3/transformer.spec.ts
@@ -37,7 +37,7 @@ describe("v2-to-v3", () => {
   describe.each(fixtureSubDirs)("%s", (subDir) => {
     const subDirPath = join(fixtureDir, subDir);
     it.concurrent.each(getTestFileMetadata(subDirPath))(
-      `transforms: %s.%s`,
+      "transforms: %s.%s",
       async (filePrefix, fileExtension) => {
         const { input, outputCode } = await getTestMetadata(subDirPath, filePrefix, fileExtension);
 


### PR DESCRIPTION
### Issue

Biome rule https://biomejs.dev/linter/rules/no-unused-template-literal/

### Description

Disallow template literals if interpolation and special-character handling are not needed

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
