### PR TITLE
Remove precommit hooks

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,6 +1,0 @@
-pre-commit:
-  commands:
-    check:
-      glob: "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc}"
-      run: yarn biome check --write --no-errors-on-unmatched --files-ignore-unknown=true {staged_files}
-      stage_fixed: true

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "build": "tsc",
     "format": "biome format --write .",
     "lint": "biome lint --write src",
-    "prepare": "lefthook install",
     "release": "yarn build && changeset publish",
     "test": "vitest"
   },
@@ -50,7 +49,6 @@
     "@types/jscodeshift": "^0.11.11",
     "@types/node": "^16.18.101",
     "aws-sdk": "2.1641.0",
-    "lefthook": "^1.6.15",
     "tsx": "^4.7.1",
     "typescript": "~5.5.2",
     "vitest": "~2.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1520,7 +1520,6 @@ __metadata:
     "@types/node": "npm:^16.18.101"
     aws-sdk: "npm:2.1641.0"
     jscodeshift: "npm:0.16.1"
-    lefthook: "npm:^1.6.15"
     tsx: "npm:^4.7.1"
     typescript: "npm:~5.5.2"
     vitest: "npm:~2.0.1"
@@ -2845,97 +2844,6 @@ __metadata:
   version: 6.0.3
   resolution: "kind-of@npm:6.0.3"
   checksum: 10c0/61cdff9623dabf3568b6445e93e31376bee1cdb93f8ba7033d86022c2a9b1791a1d9510e026e6465ebd701a6dd2f7b0808483ad8838341ac52f003f512e0b4c4
-  languageName: node
-  linkType: hard
-
-"lefthook-darwin-arm64@npm:1.6.15":
-  version: 1.6.15
-  resolution: "lefthook-darwin-arm64@npm:1.6.15"
-  conditions: os=darwin & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"lefthook-darwin-x64@npm:1.6.15":
-  version: 1.6.15
-  resolution: "lefthook-darwin-x64@npm:1.6.15"
-  conditions: os=darwin & cpu=x64
-  languageName: node
-  linkType: hard
-
-"lefthook-freebsd-arm64@npm:1.6.15":
-  version: 1.6.15
-  resolution: "lefthook-freebsd-arm64@npm:1.6.15"
-  conditions: os=freebsd & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"lefthook-freebsd-x64@npm:1.6.15":
-  version: 1.6.15
-  resolution: "lefthook-freebsd-x64@npm:1.6.15"
-  conditions: os=freebsd & cpu=x64
-  languageName: node
-  linkType: hard
-
-"lefthook-linux-arm64@npm:1.6.15":
-  version: 1.6.15
-  resolution: "lefthook-linux-arm64@npm:1.6.15"
-  conditions: os=linux & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"lefthook-linux-x64@npm:1.6.15":
-  version: 1.6.15
-  resolution: "lefthook-linux-x64@npm:1.6.15"
-  conditions: os=linux & cpu=x64
-  languageName: node
-  linkType: hard
-
-"lefthook-windows-arm64@npm:1.6.15":
-  version: 1.6.15
-  resolution: "lefthook-windows-arm64@npm:1.6.15"
-  conditions: os=win32 & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"lefthook-windows-x64@npm:1.6.15":
-  version: 1.6.15
-  resolution: "lefthook-windows-x64@npm:1.6.15"
-  conditions: os=win32 & cpu=x64
-  languageName: node
-  linkType: hard
-
-"lefthook@npm:^1.6.15":
-  version: 1.6.15
-  resolution: "lefthook@npm:1.6.15"
-  dependencies:
-    lefthook-darwin-arm64: "npm:1.6.15"
-    lefthook-darwin-x64: "npm:1.6.15"
-    lefthook-freebsd-arm64: "npm:1.6.15"
-    lefthook-freebsd-x64: "npm:1.6.15"
-    lefthook-linux-arm64: "npm:1.6.15"
-    lefthook-linux-x64: "npm:1.6.15"
-    lefthook-windows-arm64: "npm:1.6.15"
-    lefthook-windows-x64: "npm:1.6.15"
-  dependenciesMeta:
-    lefthook-darwin-arm64:
-      optional: true
-    lefthook-darwin-x64:
-      optional: true
-    lefthook-freebsd-arm64:
-      optional: true
-    lefthook-freebsd-x64:
-      optional: true
-    lefthook-linux-arm64:
-      optional: true
-    lefthook-linux-x64:
-      optional: true
-    lefthook-windows-arm64:
-      optional: true
-    lefthook-windows-x64:
-      optional: true
-  bin:
-    lefthook: bin/index.js
-  checksum: 10c0/582e4ab1f0b3e28cfbc9e773e0027e78c9660448e098740363611873495f127ce0f04efaafbee88425c6a8b88a1f4fe2b0bbe335ac59a8c65705098ba0e68112
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Issue

Fixes: https://github.com/aws/aws-sdk-js-codemod/issues/906

### Description

Removes precommit hooks

### Testing

Precommit hooks are not run
```console
$ git commit -m "chore(deps-dev): remove precommit hooks"
[remove-precommit-hooks b1e75b6] chore(deps-dev): remove precommit hooks
 3 files changed, 100 deletions(-)
 delete mode 100644 lefthook.yml
```

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
