### PR TITLE
Run biome linter and organize imports on File Save

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,7 @@
 {
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": "explicit"
+    "quickfix.biome": "explicit",
+    "source.organizeImports.biome": "explicit"
   },
   "editor.formatOnSave": true,
   "editor.defaultFormatter": "biomejs.biome",


### PR DESCRIPTION
### Issue

* Missed when migrating to Biome in https://github.com/aws/aws-sdk-js-codemod/pull/886
* Docs: https://biomejs.dev/reference/vscode/#fix-on-save

### Description

Runs biome linter and organize imports on File Save

### Testing

Verified that linter is run, and imports are organized on file save

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
