### PR TITLE
Remove @ts-ignore for inferred type predicates

### DIFF
--- a/src/transforms/v2-to-v3/client-instances/getObjectWithUpdatedAwsConfigKeys.ts
+++ b/src/transforms/v2-to-v3/client-instances/getObjectWithUpdatedAwsConfigKeys.ts
@@ -119,6 +119,5 @@ export const getObjectWithUpdatedAwsConfigKeys = (
     })
     .filter((property) => property !== undefined);
 
-  // @ts-ignore is Argument is not assignable to parameter
   return j.objectExpression(updatedProperties);
 };


### PR DESCRIPTION
### Issue

* Inferred Type Predicates https://devblogs.microsoft.com/typescript/announcing-typescript-5-5/#inferred-type-predicates
* The `@ts-ignore` is no longer required after bumping TypeScript to 5.5 https://github.com/aws/aws-sdk-js-codemod/pull/877

### Description

Remove @ts-ignore for inferred type predicates

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
