### PR TITLE
Remove redundant @ts-ignore from file with @ts-nocheck

### DIFF
--- a/src/utils/getJsCodeshiftParser.ts
+++ b/src/utils/getJsCodeshiftParser.ts
@@ -8,7 +8,6 @@ import { dirname, join } from "node:path";
 import { DEFAULT_EXTENSIONS } from "@babel/core";
 import argsParser from "jscodeshift/dist/argsParser";
 
-// @ts-ignore: package.json will be imported from dist folders
 import { version } from "../../package.json";
 
 const requirePackage = (name: string) => {


### PR DESCRIPTION
### Issue

* Noticed while removing https://github.com/aws/aws-sdk-js-codemod/pull/909
* The `@ts-ignore` is not required since the file has `@ts-nocheck`

### Description

Remove redundant `@ts-ignore` from file with `@ts-nocheck`

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
