### PR TITLE
Replace `@ts-ignore` with `@ts-expect-error`

### DIFF
--- a/src/transforms/v2-to-v3/ts-type/getTypeForString.ts
+++ b/src/transforms/v2-to-v3/ts-type/getTypeForString.ts
@@ -31,7 +31,7 @@ export const getTypeForString = (
     return j.tsTypeReference.from({
       typeName: j.identifier("Array"),
 
-      // @ts-ignore
+      // @ts-expect-error Type 'TSType' is not assignable to type 'TSTypeKind'.
       typeParameters: j.tsTypeParameterInstantiation([typeArgument]),
     });
   }
@@ -43,7 +43,7 @@ export const getTypeForString = (
     return j.tsTypeReference.from({
       typeName: j.identifier("Record"),
 
-      // @ts-ignore
+      // @ts-expect-error Type 'TSType' is not assignable to type 'TSTypeKind'.
       typeParameters: j.tsTypeParameterInstantiation([j.tsStringKeyword(), typeArgument]),
     });
   }

--- a/src/transforms/v2-to-v3/utils/getMostUsedStringLiteralQuote.ts
+++ b/src/transforms/v2-to-v3/utils/getMostUsedStringLiteralQuote.ts
@@ -19,7 +19,7 @@ export const getMostUsedStringLiteralQuote = (
 
     // Check if the literal value is a string and contains single quotes
     if (typeof value === "string") {
-      // @ts-ignore Property 'raw' does not exist on type 'Literal'.
+      // @ts-expect-error Property 'raw' does not exist on type 'Literal'.
       const rawValue = path.node.raw || path.node.extra?.raw || "";
       if (rawValue.startsWith("'")) {
         quoteCount[StringLiteralQuoteType.SINGLE]++;

--- a/src/transforms/v2-to-v3/utils/isTrailingCommaUsed.ts
+++ b/src/transforms/v2-to-v3/utils/isTrailingCommaUsed.ts
@@ -2,7 +2,7 @@ import type { Collection, JSCodeshift } from "jscodeshift";
 
 export const isTrailingCommaUsed = (j: JSCodeshift, source: Collection<unknown>) => {
   for (const node of source.find(j.ObjectExpression).nodes()) {
-    // @ts-ignore Property 'extra' does not exist on type 'ObjectExpression'.
+    // @ts-expect-error Property 'extra' does not exist on type 'ObjectExpression'.
     if (node.extra?.trailingComma) {
       return true;
     }


### PR DESCRIPTION
### Issue

Ensures that redundant `@ts-expect-error` can be removed if types or TypeScript is updated.
The `@ts-expect-error` would have caught https://github.com/aws/aws-sdk-js-codemod/pull/909 when upgrading to TypeScript 5.5

### Description

Replaces `@ts-ignore` with `@ts-expect-error`

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
