### PR TITLE
Remove type assertions while generating client types map

### DIFF
--- a/.changeset/clean-bikes-end.md
+++ b/.changeset/clean-bikes-end.md
@@ -1,0 +1,5 @@
+---
+"aws-sdk-js-codemod": minor
+---
+
+Remove type assertions while generating client types map

--- a/scripts/generateClientTypesMap/getClientReqRespTypesMap.ts
+++ b/scripts/generateClientTypesMap/getClientReqRespTypesMap.ts
@@ -1,9 +1,4 @@
-import jscodeshift, {
-  type Identifier,
-  type TSFunctionType,
-  type TSQualifiedName,
-  type TSTypeReference,
-} from "jscodeshift";
+import jscodeshift from "jscodeshift";
 
 import { getTypesSource } from "./getTypesSource";
 
@@ -23,58 +18,58 @@ export const getClientReqRespTypesMap = async (
       if (classMethod.key.name === "constructor") return;
       if (classMethod.key.name.startsWith("waitFor")) return;
 
-      const classMethodKeyName = (classMethod.key as Identifier).name;
+      const classMethodKeyName = classMethod.key.name;
       const commandName = classMethodKeyName.charAt(0).toUpperCase() + classMethodKeyName.slice(1);
 
       if (classMethod.params.length !== 2) return;
       if (classMethod.params[0].type !== "Identifier") return;
       if (classMethod.params[0].name !== "params") return;
 
-      const params = classMethod.params[0] as Identifier;
+      const params = classMethod.params[0];
 
       if (!params.typeAnnotation) return;
       if (!params.typeAnnotation.typeAnnotation) return;
       if (params.typeAnnotation.typeAnnotation.type !== "TSTypeReference") return;
-      const paramsTypeRef = params.typeAnnotation.typeAnnotation as TSTypeReference;
+      const paramsTypeRef = params.typeAnnotation.typeAnnotation;
 
       if (!paramsTypeRef.typeName) return;
       if (paramsTypeRef.typeName.type !== "TSQualifiedName") return;
-      const paramsTypeRefName = paramsTypeRef.typeName as TSQualifiedName;
+      const paramsTypeRefName = paramsTypeRef.typeName;
 
       if (!paramsTypeRefName.right) return;
       if (paramsTypeRefName.right.type !== "Identifier") return;
-      const paramsTypeName = paramsTypeRefName.right as Identifier;
+      const paramsTypeName = paramsTypeRefName.right;
       const requestTypeName = paramsTypeName.name;
 
       clientTypesMap[requestTypeName] = `${commandName}CommandInput`;
 
       if (classMethod.params[1].type !== "Identifier") return;
       if (classMethod.params[1].name !== "callback") return;
-      const callback = classMethod.params[1] as Identifier;
+      const callback = classMethod.params[1];
 
       if (!callback.typeAnnotation) return;
       if (!callback.typeAnnotation.typeAnnotation) return;
       if (callback.typeAnnotation.typeAnnotation.type !== "TSFunctionType") return;
-      const callbackTypeRef = callback.typeAnnotation.typeAnnotation as TSFunctionType;
+      const callbackTypeRef = callback.typeAnnotation.typeAnnotation;
 
       if (!callbackTypeRef.parameters) return;
       if (callbackTypeRef.parameters.length !== 2) return;
       if (callbackTypeRef.parameters[1].type !== "Identifier") return;
-      const responseType = callbackTypeRef.parameters[1] as Identifier;
+      const responseType = callbackTypeRef.parameters[1];
 
       if (!responseType.typeAnnotation) return;
       if (responseType.typeAnnotation.type !== "TSTypeAnnotation") return;
       if (!responseType.typeAnnotation.typeAnnotation) return;
       if (responseType.typeAnnotation.typeAnnotation.type !== "TSTypeReference") return;
-      const responseTypeRef = responseType.typeAnnotation.typeAnnotation as TSTypeReference;
+      const responseTypeRef = responseType.typeAnnotation.typeAnnotation;
 
       if (!responseTypeRef.typeName) return;
       if (responseTypeRef.typeName.type !== "TSQualifiedName") return;
-      const responseTypeRefName = responseTypeRef.typeName as TSQualifiedName;
+      const responseTypeRefName = responseTypeRef.typeName;
 
       if (!responseTypeRefName.right) return;
       if (responseTypeRefName.right.type !== "Identifier") return;
-      const responseTypeName = (responseTypeRefName.right as Identifier).name;
+      const responseTypeName = responseTypeRefName.right.name;
 
       clientTypesMap[responseTypeName] = `${commandName}CommandOutput`;
     });


### PR DESCRIPTION
### Issue

Feature introduces in TypeScript 5.4 https://devblogs.microsoft.com/typescript/announcing-typescript-5-4/#preserved-narrowing-in-closures-following-last-assignments

### Description

Removes type assertions in closures following assignments

### Testing

Verified that client types map is not updated on running CI
```console
$ yarn tsx scripts/generateClientTypesMap/index.ts
```

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
