### PR TITLE
Ignore list from .gitignore in biome

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -30,8 +30,12 @@
       "suspicious": {
         "noEmptyBlockStatements": "error"
       }
-    },
-    "ignore": ["**/__fixtures__"]
+    }
   },
-  "javascript": { "formatter": { "trailingCommas": "es5" } }
+  "javascript": { "formatter": { "trailingCommas": "es5" } },
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  }
 }


### PR DESCRIPTION
### Issue

* Docs: https://biomejs.dev/guides/integrate-in-vcs/
* Missed in https://github.com/aws/aws-sdk-js-codemod/pull/886

### Description

Ignore files from `.gitignore` in biome

### Testing

* CI
* Verified by opening `namedTypes.d.ts` that biome is not run on it.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
