### PR TITLE
Remove redundant dot character in biome scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
   },
   "scripts": {
     "build": "tsc",
-    "format": "biome format --write .",
-    "lint": "biome lint --write .",
+    "format": "biome format --write",
+    "lint": "biome lint --write",
     "release": "yarn build && changeset publish",
     "test": "vitest"
   },


### PR DESCRIPTION
### Issue

N/A

### Description

Removes redundant dot character in biome scripts

### Testing

```console
$> yarn format
Formatted 198 files in 91ms. No fixes needed.
$> yarn lint
Checked 198 files in 131ms. No fixes needed.
```

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
