### PR TITLE
Remove type assertions for Literal and StringLiteral

### DIFF
--- a/.changeset/tricky-tigers-smash.md
+++ b/.changeset/tricky-tigers-smash.md
@@ -1,0 +1,5 @@
+---
+"aws-sdk-js-codemod": patch
+---
+
+Remove type assertions for Literal and StringLiteral

--- a/src/transforms/v2-to-v3/apis/getS3SignedUrlApiNames.ts
+++ b/src/transforms/v2-to-v3/apis/getS3SignedUrlApiNames.ts
@@ -1,4 +1,4 @@
-import type { Collection, JSCodeshift, Literal } from "jscodeshift";
+import type { Collection, JSCodeshift } from "jscodeshift";
 
 import type { ClientIdentifier } from "../types";
 
@@ -20,7 +20,14 @@ export const getS3SignedUrlApiNames = (
           },
         })
         .forEach((callExpression) => {
-          apiNames.add((callExpression.value.arguments[0] as Literal).value as string);
+          const callExpressionArg = callExpression.value.arguments[0];
+          if (callExpressionArg.type !== "Literal" && callExpressionArg.type !== "StringLiteral") {
+            return;
+          }
+          if (typeof callExpressionArg.value !== "string") {
+            return;
+          }
+          apiNames.add(callExpressionArg.value);
         });
     }
   }

--- a/src/transforms/v2-to-v3/apis/replaceS3GetSignedUrlApi.ts
+++ b/src/transforms/v2-to-v3/apis/replaceS3GetSignedUrlApi.ts
@@ -1,7 +1,6 @@
 import type {
   Collection,
   JSCodeshift,
-  Literal,
   NewExpression,
   ObjectExpression,
   ObjectProperty,
@@ -26,7 +25,15 @@ export const replaceS3GetSignedUrlApi = (
         .replaceWith((callExpression) => {
           const args = callExpression.node.arguments;
 
-          const apiName = (args[0] as Literal).value as string;
+          if (args[0].type !== "Literal" && args[0].type !== "StringLiteral") {
+            return callExpression;
+          }
+
+          if (typeof args[0].value !== "string") {
+            return callExpression;
+          }
+
+          const apiName = args[0].value;
           const params = args[1];
 
           const options = j.objectExpression([]);

--- a/src/transforms/v2-to-v3/config/constants.ts
+++ b/src/transforms/v2-to-v3/config/constants.ts
@@ -12,6 +12,5 @@ export const FUNCTION_TYPE_LIST = [
   "FunctionExpression",
   "ArrowFunctionExpression",
 ];
-export const STRING_LITERAL_TYPE_LIST = ["Literal", "StringLiteral"];
 
 export const NOT_SUPPORTED_COMMENT = "not supported in AWS SDK for JavaScript (v3)";

--- a/src/transforms/v2-to-v3/modules/importEqualsModule/getImportEqualsDeclarations.ts
+++ b/src/transforms/v2-to-v3/modules/importEqualsModule/getImportEqualsDeclarations.ts
@@ -1,9 +1,4 @@
-import type {
-  Collection,
-  JSCodeshift,
-  StringLiteral,
-  TSExternalModuleReference,
-} from "jscodeshift";
+import type { Collection, JSCodeshift, TSExternalModuleReference } from "jscodeshift";
 import { PACKAGE_NAME } from "../../config";
 
 export const getImportEqualsDeclarations = (
@@ -22,7 +17,7 @@ export const getImportEqualsDeclarations = (
     .filter((importEqualsDeclaration) => {
       const moduleReference = importEqualsDeclaration.value
         .moduleReference as TSExternalModuleReference;
-      const expressionValue = (moduleReference.expression as StringLiteral).value;
+      const expressionValue = moduleReference.expression.value;
       if (path) {
         return expressionValue === path;
       }

--- a/src/transforms/v2-to-v3/modules/requireModule/addNamedModule.ts
+++ b/src/transforms/v2-to-v3/modules/requireModule/addNamedModule.ts
@@ -1,14 +1,6 @@
-import type {
-  Collection,
-  JSCodeshift,
-  Literal,
-  ObjectPattern,
-  ObjectProperty,
-  Property,
-  StringLiteral,
-} from "jscodeshift";
+import type { Collection, JSCodeshift, ObjectPattern, ObjectProperty, Property } from "jscodeshift";
 
-import { OBJECT_PROPERTY_TYPE_LIST, PACKAGE_NAME, STRING_LITERAL_TYPE_LIST } from "../../config";
+import { OBJECT_PROPERTY_TYPE_LIST, PACKAGE_NAME } from "../../config";
 import { objectPatternPropertyCompareFn } from "../objectPatternPropertyCompareFn";
 import { getRequireDeclarators } from "../requireModule";
 import type { ModulesOptions } from "../types";
@@ -73,11 +65,10 @@ export const addNamedModule = (
     })
     .filter((callExpression) => {
       const arg = callExpression.value.arguments[0];
-      if (!STRING_LITERAL_TYPE_LIST.includes(arg.type)) {
+      if (arg.type !== "Literal" && arg.type !== "StringLiteral") {
         return false;
       }
-      const argValue = (arg as Literal | StringLiteral).value;
-      return typeof argValue === "string" && argValue.startsWith(PACKAGE_NAME);
+      return typeof arg.value === "string" && arg.value.startsWith(PACKAGE_NAME);
     });
 
   if (v2RequireCallExpressions.size()) {

--- a/src/transforms/v2-to-v3/modules/requireModule/getRequireDeclarators.ts
+++ b/src/transforms/v2-to-v3/modules/requireModule/getRequireDeclarators.ts
@@ -1,10 +1,4 @@
-import type {
-  CallExpression,
-  Collection,
-  JSCodeshift,
-  Literal,
-  VariableDeclarator,
-} from "jscodeshift";
+import type { CallExpression, Collection, JSCodeshift, VariableDeclarator } from "jscodeshift";
 import { PACKAGE_NAME } from "../../config";
 
 const isValidRequireCallExpression = (callExpression: CallExpression, path?: string) => {
@@ -12,7 +6,12 @@ const isValidRequireCallExpression = (callExpression: CallExpression, path?: str
     return false;
   }
 
-  const { value: sourceValue } = callExpression.arguments[0] as Literal;
+  const callExpressionArg = callExpression.arguments[0];
+  if (callExpressionArg.type !== "Literal" && callExpressionArg.type !== "StringLiteral") {
+    return false;
+  }
+
+  const sourceValue = callExpressionArg.value;
   if (typeof sourceValue !== "string") {
     return false;
   }

--- a/src/transforms/v2-to-v3/modules/requireModule/removeRequire.ts
+++ b/src/transforms/v2-to-v3/modules/requireModule/removeRequire.ts
@@ -3,14 +3,12 @@ import type {
   Collection,
   Identifier,
   JSCodeshift,
-  Literal,
   ObjectPattern,
   ObjectProperty,
   Property,
-  StringLiteral,
   VariableDeclarator,
 } from "jscodeshift";
-import { OBJECT_PROPERTY_TYPE_LIST, STRING_LITERAL_TYPE_LIST } from "../../config";
+import { OBJECT_PROPERTY_TYPE_LIST } from "../../config";
 import { removeDeclaration } from "../removeDeclaration";
 import type { ImportSpecifierType } from "../types";
 import { getRequireDeclarators } from "./getRequireDeclarators";
@@ -37,9 +35,9 @@ const isAnotherSpecifier = (j: JSCodeshift, source: Collection<unknown>, localNa
       const initArgs = init.arguments;
       if (!initArgs || initArgs.length !== 0) return false;
 
-      if (STRING_LITERAL_TYPE_LIST.includes(initArgs[0].type)) return false;
+      if (initArgs[0].type !== "Literal" && initArgs[0].type !== "StringLiteral") return false;
 
-      const sourceValue = (initArgs[0] as Literal | StringLiteral).value;
+      const sourceValue = initArgs[0].value;
       if (typeof sourceValue !== "string") return false;
       return sourceValue.startsWith("@aws-sdk/");
     })


### PR DESCRIPTION
### Issue

Feature introduces in TypeScript 5.4 https://devblogs.microsoft.com/typescript/announcing-typescript-5-4/#preserved-narrowing-in-closures-following-last-assignments

### Description

Remove type assertion for Literal and StringLiteral

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
