### PR TITLE
Remove type assertions for ObjectExpression

### DIFF
--- a/.changeset/modern-dryers-sing.md
+++ b/.changeset/modern-dryers-sing.md
@@ -1,0 +1,5 @@
+---
+"aws-sdk-js-codemod": patch
+---
+
+Remove type assertions for ObjectExpression

--- a/src/transforms/v2-to-v3/apis/getArgsWithoutWaiterConfig.ts
+++ b/src/transforms/v2-to-v3/apis/getArgsWithoutWaiterConfig.ts
@@ -2,13 +2,8 @@ import type { ObjectExpression, ObjectProperty, Property } from "jscodeshift";
 
 import { OBJECT_PROPERTY_TYPE_LIST } from "../config";
 
-export const getArgsWithoutWaiterConfig = <T>(callArgument: T): T => {
-  if ((callArgument as ObjectExpression).type !== "ObjectExpression") {
-    return callArgument;
-  }
-
-  const objectExpression = callArgument as ObjectExpression;
-  objectExpression.properties = objectExpression.properties.filter((property) => {
+export const getArgsWithoutWaiterConfig = (options: ObjectExpression): ObjectExpression => {
+  options.properties = options.properties.filter((property) => {
     if (!OBJECT_PROPERTY_TYPE_LIST.includes(property.type)) {
       return true;
     }
@@ -22,6 +17,5 @@ export const getArgsWithoutWaiterConfig = <T>(callArgument: T): T => {
     return true;
   });
 
-  // @ts-expect-error Type 'ObjectExpression' is not assignable to type 'T'.
-  return objectExpression;
+  return options;
 };

--- a/src/transforms/v2-to-v3/apis/getWaiterConfig.ts
+++ b/src/transforms/v2-to-v3/apis/getWaiterConfig.ts
@@ -2,11 +2,8 @@ import type { ObjectExpression, ObjectProperty, Property } from "jscodeshift";
 
 import { OBJECT_PROPERTY_TYPE_LIST } from "../config";
 
-export const getWaiterConfig = (callArgument: unknown): ObjectExpression | undefined => {
-  if ((callArgument as ObjectExpression).type !== "ObjectExpression") {
-    return;
-  }
-  for (const property of (callArgument as ObjectExpression).properties) {
+export const getWaiterConfig = (originalConfig: ObjectExpression): ObjectExpression | undefined => {
+  for (const property of originalConfig.properties) {
     if (!OBJECT_PROPERTY_TYPE_LIST.includes(property.type)) {
       continue;
     }

--- a/src/transforms/v2-to-v3/apis/getWaiterConfigValue.ts
+++ b/src/transforms/v2-to-v3/apis/getWaiterConfigValue.ts
@@ -2,13 +2,7 @@ import type { ObjectExpression, ObjectProperty, Property } from "jscodeshift";
 
 import { OBJECT_PROPERTY_TYPE_LIST } from "../config";
 
-export const getWaiterConfigValue = (
-  waiterConfiguration: ObjectExpression | undefined,
-  key: string
-): string | undefined => {
-  if (!waiterConfiguration) {
-    return;
-  }
+export const getWaiterConfigValue = (waiterConfiguration: ObjectExpression, key: string) => {
   for (const property of waiterConfiguration.properties) {
     if (!OBJECT_PROPERTY_TYPE_LIST.includes(property.type)) {
       continue;
@@ -19,8 +13,15 @@ export const getWaiterConfigValue = (
       continue;
     }
     if (propertyKey.name === key) {
-      // @ts-expect-error value is Literal/StringLiteral
-      return propertyValue.value;
+      if (propertyValue.type === "Literal" || propertyValue.type === "StringLiteral") {
+        if (typeof propertyValue.value === "number") {
+          return propertyValue.value.toString();
+        }
+        if (typeof propertyValue.value === "string") {
+          return propertyValue.value;
+        }
+      }
+      return;
     }
   }
 };

--- a/src/transforms/v2-to-v3/apis/replaceWaiterApi.ts
+++ b/src/transforms/v2-to-v3/apis/replaceWaiterApi.ts
@@ -25,8 +25,8 @@ export const replaceWaiterApi = (
           let maxAttempts: string | undefined;
 
           const callArguments = callExpression.node.arguments;
-          if (callArguments.length > 1 && callArguments[0].type === "ObjectExpression") {
-            const waiterConfig = getWaiterConfig(callArguments[0]);
+          if (callArguments.length > 1 && callArguments[1].type === "ObjectExpression") {
+            const waiterConfig = getWaiterConfig(callArguments[1]);
             if (waiterConfig) {
               delay = getWaiterConfigValue(waiterConfig, "delay");
               maxAttempts = getWaiterConfigValue(waiterConfig, "maxAttempts");

--- a/src/transforms/v2-to-v3/apis/replaceWaiterApi.ts
+++ b/src/transforms/v2-to-v3/apis/replaceWaiterApi.ts
@@ -21,9 +21,17 @@ export const replaceWaiterApi = (
       source
         .find(j.CallExpression, getClientWaiterCallExpression(clientId, waiterState))
         .replaceWith((callExpression) => {
-          const waiterConfig = getWaiterConfig(callExpression.node.arguments[1]);
-          const delay = getWaiterConfigValue(waiterConfig, "delay");
-          const maxAttempts = getWaiterConfigValue(waiterConfig, "maxAttempts");
+          let delay: string | undefined;
+          let maxAttempts: string | undefined;
+
+          const callArguments = callExpression.node.arguments;
+          if (callArguments.length > 1 && callArguments[0].type === "ObjectExpression") {
+            const waiterConfig = getWaiterConfig(callArguments[0]);
+            if (waiterConfig) {
+              delay = getWaiterConfigValue(waiterConfig, "delay");
+              maxAttempts = getWaiterConfigValue(waiterConfig, "maxAttempts");
+            }
+          }
 
           const properties = [];
           properties.push(

--- a/src/transforms/v2-to-v3/apis/replaceWaiterApi.ts
+++ b/src/transforms/v2-to-v3/apis/replaceWaiterApi.ts
@@ -54,9 +54,12 @@ export const replaceWaiterApi = (
             })
           );
 
+          const options = callExpression.node.arguments[1];
+          const updatedOptions =
+            options.type === "ObjectExpression" ? getArgsWithoutWaiterConfig(options) : options;
           return j.callExpression(j.identifier(getV3ClientWaiterApiName(waiterState)), [
             j.objectExpression(properties),
-            getArgsWithoutWaiterConfig(callExpression.node.arguments[1]),
+            updatedOptions,
           ]);
         });
     }

--- a/src/transforms/v2-to-v3/client-instances/getAwsGlobalConfig.ts
+++ b/src/transforms/v2-to-v3/client-instances/getAwsGlobalConfig.ts
@@ -28,12 +28,13 @@ export const getAwsGlobalConfig = (
         property: { type: "Identifier", name: "update" },
       },
     })
-    .filter(
-      ({ node }) => node.arguments.length === 1 && node.arguments[0].type === "ObjectExpression"
-    )
-    .forEach(({ node }) => {
-      const objectExpressionProperties = (node.arguments[0] as ObjectExpression).properties;
+    .forEach((callExpression) => {
+      const node = callExpression.node;
+      if (node.arguments.length !== 1 || node.arguments[0].type !== "ObjectExpression") {
+        return;
+      }
 
+      const objectExpressionProperties = node.arguments[0].properties;
       objectExpressionProperties.forEach((property) => {
         objectExpression.properties.push(property);
       });

--- a/src/transforms/v2-to-v3/client-instances/replaceAwsConfig.ts
+++ b/src/transforms/v2-to-v3/client-instances/replaceAwsConfig.ts
@@ -21,16 +21,16 @@ export const replaceAwsConfig = (
         property: { type: "Identifier", name: "Config" },
       },
     })
-    .filter(
-      ({ node }) =>
-        node.arguments.length === 0 ||
-        (node.arguments.length === 1 && node.arguments[0].type === "ObjectExpression")
-    )
-    .replaceWith(({ node }) => {
-      const objectExpression =
-        node.arguments.length === 0
-          ? j.objectExpression([])
-          : (node.arguments[0] as ObjectExpression);
-      return getObjectWithUpdatedAwsConfigKeys(j, objectExpression, awsGlobalConfig);
+    .replaceWith((newExpression) => {
+      const nodeArguments = newExpression.node.arguments;
+
+      if (nodeArguments.length === 0) {
+        return getObjectWithUpdatedAwsConfigKeys(j, j.objectExpression([]), awsGlobalConfig);
+      }
+      if (nodeArguments.length === 1 && nodeArguments[0].type === "ObjectExpression") {
+        return getObjectWithUpdatedAwsConfigKeys(j, nodeArguments[0], awsGlobalConfig);
+      }
+
+      return newExpression;
     });
 };


### PR DESCRIPTION
### Issue

Feature introduces in TypeScript 5.4 https://devblogs.microsoft.com/typescript/announcing-typescript-5-4/#preserved-narrowing-in-closures-following-last-assignments

### Description

Removes type assertions for ObjectExpression

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
