### PR TITLE
Remove type assertions for Identifier

### DIFF
--- a/.changeset/itchy-mugs-rest.md
+++ b/.changeset/itchy-mugs-rest.md
@@ -1,0 +1,5 @@
+---
+"aws-sdk-js-codemod": patch
+---
+
+Remove type assertions for Identifier

--- a/src/transforms/v2-to-v3/client-instances/getObjectWithUpdatedAwsConfigKeys.ts
+++ b/src/transforms/v2-to-v3/client-instances/getObjectWithUpdatedAwsConfigKeys.ts
@@ -42,7 +42,7 @@ export const getObjectWithUpdatedAwsConfigKeys = (
       continue;
     }
 
-    const propertyKeyName = (propertyKey as Identifier).name;
+    const propertyKeyName = propertyKey.name;
     if (
       !propertiesToUpdate
         .filter((propertyToUpdate) => OBJECT_PROPERTY_TYPE_LIST.includes(propertyToUpdate.type))

--- a/src/transforms/v2-to-v3/client-names/getNamesFromTSQualifiedName.ts
+++ b/src/transforms/v2-to-v3/client-names/getNamesFromTSQualifiedName.ts
@@ -8,6 +8,7 @@ export const getNamesFromTSQualifiedName = (
   source
     .find(j.TSQualifiedName, {
       left: { name: v2GlobalName },
+      right: { type: "Identifier" },
     })
     .nodes()
     .map((tsTypeReference) => (tsTypeReference.right as Identifier).name);

--- a/src/transforms/v2-to-v3/modules/getGlobalNameFromModule.ts
+++ b/src/transforms/v2-to-v3/modules/getGlobalNameFromModule.ts
@@ -1,4 +1,4 @@
-import type { Collection, Identifier, JSCodeshift } from "jscodeshift";
+import type { Collection, JSCodeshift } from "jscodeshift";
 
 import { PACKAGE_NAME } from "../config";
 import { getImportSpecifiers as getImportEqualsSpecifiers } from "../modules/importEqualsModule";
@@ -13,8 +13,8 @@ export const getGlobalNameFromModule = (
     .filter((declarator) => declarator.value.id.type === "Identifier")
     .nodes();
 
-  if (requireIdentifiers.length > 0) {
-    return (requireIdentifiers[0]?.id as Identifier).name;
+  if (requireIdentifiers.length > 0 && requireIdentifiers[0].id.type === "Identifier") {
+    return requireIdentifiers[0].id.name;
   }
 
   const importDefaultSpecifiers = getImportSpecifiers(j, source, PACKAGE_NAME).filter(

--- a/src/transforms/v2-to-v3/modules/getRequireDeclaratorsWithProperty.ts
+++ b/src/transforms/v2-to-v3/modules/getRequireDeclaratorsWithProperty.ts
@@ -1,4 +1,4 @@
-import type { Collection, Identifier, JSCodeshift } from "jscodeshift";
+import type { Collection, JSCodeshift } from "jscodeshift";
 import { getRequireDeclarators } from "./requireModule";
 
 export interface GetRequireDeclaratorsWithPropertyOptions {
@@ -18,8 +18,11 @@ export const getRequireDeclaratorsWithProperty = (
 
     if (declaratorId.type === "Identifier") {
       const declaratorIdName = declaratorId.name;
-      if (declaratorInit?.type === "MemberExpression") {
-        const importedName = (declaratorInit.property as Identifier).name;
+      if (
+        declaratorInit?.type === "MemberExpression" &&
+        declaratorInit.property.type === "Identifier"
+      ) {
+        const importedName = declaratorInit.property.name;
         if (localName === declaratorIdName && identifierName === importedName) {
           return true;
         }

--- a/src/transforms/v2-to-v3/modules/requireModule/getImportSpecifiers.ts
+++ b/src/transforms/v2-to-v3/modules/requireModule/getImportSpecifiers.ts
@@ -1,4 +1,4 @@
-import type { Collection, Identifier, JSCodeshift, ObjectProperty, Property } from "jscodeshift";
+import type { Collection, JSCodeshift, ObjectProperty, Property } from "jscodeshift";
 import { OBJECT_PROPERTY_TYPE_LIST } from "../../config";
 import type { ImportSpecifierType } from "../types";
 import { getRequireDeclarators } from "./getRequireDeclarators";
@@ -37,9 +37,12 @@ export const getImportSpecifiers = (
 
     if (declaratorId.type === "Identifier") {
       const declaratorIdName = declaratorId.name;
-      if (declaratorInit?.type === "MemberExpression") {
+      if (
+        declaratorInit?.type === "MemberExpression" &&
+        declaratorInit.property.type === "Identifier"
+      ) {
         importSpecifiers.add({
-          importedName: (declaratorInit.property as Identifier).name,
+          importedName: declaratorInit.property.name,
           localName: declaratorIdName,
         });
       } else {

--- a/src/transforms/v2-to-v3/ts-type/getClientTypeNames.ts
+++ b/src/transforms/v2-to-v3/ts-type/getClientTypeNames.ts
@@ -1,10 +1,4 @@
-import type {
-  Collection,
-  Identifier,
-  JSCodeshift,
-  TSQualifiedName,
-  TSTypeReference,
-} from "jscodeshift";
+import type { Collection, JSCodeshift, TSQualifiedName, TSTypeReference } from "jscodeshift";
 
 import type { ImportSpecifierType } from "../modules";
 import { getImportSpecifiers } from "../modules/importModule";
@@ -30,7 +24,7 @@ const getRightIdentifierName = (
     .nodes()
     .map((node) => (node.typeName as TSQualifiedName).right)
     .filter((node) => node.type === "Identifier")
-    .map((node) => (node as Identifier).name);
+    .map((node) => node.name);
 
 export const getClientTypeNames = (
   j: JSCodeshift,


### PR DESCRIPTION
### Issue

Feature introduces in TypeScript 5.4 https://devblogs.microsoft.com/typescript/announcing-typescript-5-4/#preserved-narrowing-in-closures-following-last-assignments

### Description

Removes type assertions for Identifier

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
