### PR TITLE
Remove type assertions for Property and ObjectProperty

### DIFF
--- a/.changeset/thick-cycles-add.md
+++ b/.changeset/thick-cycles-add.md
@@ -1,0 +1,5 @@
+---
+"aws-sdk-js-codemod": patch
+---
+
+Remove type assertions for Property and ObjectProperty

--- a/src/transforms/v2-to-v3/apis/getArgsWithoutWaiterConfig.ts
+++ b/src/transforms/v2-to-v3/apis/getArgsWithoutWaiterConfig.ts
@@ -1,13 +1,11 @@
-import type { ObjectExpression, ObjectProperty, Property } from "jscodeshift";
-
-import { OBJECT_PROPERTY_TYPE_LIST } from "../config";
+import type { ObjectExpression } from "jscodeshift";
 
 export const getArgsWithoutWaiterConfig = (options: ObjectExpression): ObjectExpression => {
   options.properties = options.properties.filter((property) => {
-    if (!OBJECT_PROPERTY_TYPE_LIST.includes(property.type)) {
+    if (property.type !== "Property" && property.type !== "ObjectProperty") {
       return true;
     }
-    const propertyKey = (property as Property | ObjectProperty).key;
+    const propertyKey = property.key;
     if (propertyKey.type !== "Identifier") {
       return true;
     }

--- a/src/transforms/v2-to-v3/apis/getWaiterConfig.ts
+++ b/src/transforms/v2-to-v3/apis/getWaiterConfig.ts
@@ -1,19 +1,15 @@
-import type { ObjectExpression, ObjectProperty, Property } from "jscodeshift";
-
-import { OBJECT_PROPERTY_TYPE_LIST } from "../config";
+import type { ObjectExpression } from "jscodeshift";
 
 export const getWaiterConfig = (originalConfig: ObjectExpression): ObjectExpression | undefined => {
   for (const property of originalConfig.properties) {
-    if (!OBJECT_PROPERTY_TYPE_LIST.includes(property.type)) {
+    if (property.type !== "Property" && property.type !== "ObjectProperty") {
       continue;
     }
-    const propertyKey = (property as Property | ObjectProperty).key;
-    const propertyValue = (property as Property | ObjectProperty).value;
-    if (propertyKey.type !== "Identifier" || propertyValue.type !== "ObjectExpression") {
+    if (property.key.type !== "Identifier" || property.value.type !== "ObjectExpression") {
       continue;
     }
-    if (propertyKey.name === "$waiter") {
-      return propertyValue;
+    if (property.key.name === "$waiter") {
+      return property.value;
     }
   }
 };

--- a/src/transforms/v2-to-v3/apis/getWaiterConfigValue.ts
+++ b/src/transforms/v2-to-v3/apis/getWaiterConfigValue.ts
@@ -1,18 +1,15 @@
-import type { ObjectExpression, ObjectProperty, Property } from "jscodeshift";
-
-import { OBJECT_PROPERTY_TYPE_LIST } from "../config";
+import type { ObjectExpression } from "jscodeshift";
 
 export const getWaiterConfigValue = (waiterConfiguration: ObjectExpression, key: string) => {
   for (const property of waiterConfiguration.properties) {
-    if (!OBJECT_PROPERTY_TYPE_LIST.includes(property.type)) {
+    if (property.type !== "Property" && property.type !== "ObjectProperty") {
       continue;
     }
-    const propertyKey = (property as Property | ObjectProperty).key;
-    const propertyValue = (property as Property | ObjectProperty).value;
-    if (propertyKey.type !== "Identifier") {
+    if (property.key.type !== "Identifier") {
       continue;
     }
-    if (propertyKey.name === key) {
+    if (property.key.name === key) {
+      const propertyValue = property.value;
       if (propertyValue.type === "Literal" || propertyValue.type === "StringLiteral") {
         if (typeof propertyValue.value === "number") {
           return propertyValue.value.toString();

--- a/src/transforms/v2-to-v3/apis/replaceS3GetSignedUrlApi.ts
+++ b/src/transforms/v2-to-v3/apis/replaceS3GetSignedUrlApi.ts
@@ -1,13 +1,5 @@
-import type {
-  Collection,
-  JSCodeshift,
-  NewExpression,
-  ObjectExpression,
-  ObjectProperty,
-  Property,
-} from "jscodeshift";
+import type { Collection, JSCodeshift, NewExpression, ObjectExpression } from "jscodeshift";
 
-import { OBJECT_PROPERTY_TYPE_LIST } from "../config";
 import type { ClientIdentifier } from "../types";
 import { getClientApiCallExpression } from "./getClientApiCallExpression";
 import { getCommandName } from "./getCommandName";
@@ -41,26 +33,26 @@ export const replaceS3GetSignedUrlApi = (
           if (params.type === "ObjectExpression") {
             // Check if params has property 'Expires' and add it to options.
             for (const property of params.properties) {
-              if (!OBJECT_PROPERTY_TYPE_LIST.includes(property.type)) continue;
-              const propertyKey = (property as Property | ObjectProperty).key;
-              const propertyValue = (property as Property | ObjectProperty).value;
-              if (propertyKey.type === "Identifier") {
-                const propertyKeyName = propertyKey.name;
-                if (propertyKeyName === "Expires") {
+              if (property.type !== "Property" && property.type !== "ObjectProperty") {
+                continue;
+              }
+              if (property.key.type === "Identifier") {
+                if (property.key.name === "Expires") {
                   // Add 'expiresIn' property to options.
                   options.properties.push(
                     j.objectProperty.from({
                       key: j.identifier("expiresIn"),
-                      value: propertyValue,
+                      value: property.value,
                       shorthand: true,
                     })
                   );
                   // Remove 'Expires' property from params.
                   params.properties = params.properties.filter((property) => {
-                    if (!OBJECT_PROPERTY_TYPE_LIST.includes(property.type)) return true;
-                    const propertyKey = (property as Property | ObjectProperty).key;
-                    if (propertyKey.type !== "Identifier") return true;
-                    return propertyKey.name !== "Expires";
+                    if (property.type !== "Property" && property.type !== "ObjectProperty") {
+                      return true;
+                    }
+                    if (property.key.type !== "Identifier") return true;
+                    return property.key.name !== "Expires";
                   });
                 }
               }

--- a/src/transforms/v2-to-v3/client-instances/getDynamoDBDocClientArgs.ts
+++ b/src/transforms/v2-to-v3/client-instances/getDynamoDBDocClientArgs.ts
@@ -1,5 +1,4 @@
-import type { ASTPath, JSCodeshift, NewExpression, ObjectProperty, Property } from "jscodeshift";
-import { OBJECT_PROPERTY_TYPE_LIST } from "../config";
+import type { ASTPath, JSCodeshift, NewExpression } from "jscodeshift";
 import { getDynamoDBForDocClient } from "./getDynamoDBForDocClient";
 
 export const getDynamoDBDocClientArgs = (
@@ -16,11 +15,11 @@ export const getDynamoDBDocClientArgs = (
     const params = v2DocClientArgs[0];
     if (params.type === "ObjectExpression") {
       for (const property of params.properties) {
-        if (!OBJECT_PROPERTY_TYPE_LIST.includes(property.type)) {
+        if (property.type !== "Property" && property.type !== "ObjectProperty") {
           continue;
         }
 
-        const propertyKey = (property as Property | ObjectProperty).key;
+        const propertyKey = property.key;
         if (propertyKey.type !== "Identifier") {
           continue;
         }
@@ -36,11 +35,7 @@ export const getDynamoDBDocClientArgs = (
               "init",
               j.identifier(docClientOptionsHash[propertyKey.name]),
               j.objectExpression([
-                j.property(
-                  "init",
-                  j.identifier(propertyKey.name),
-                  (property as Property | ObjectProperty).value
-                ),
+                j.property("init", j.identifier(propertyKey.name), property.value),
               ])
             )
           );

--- a/src/transforms/v2-to-v3/config/constants.ts
+++ b/src/transforms/v2-to-v3/config/constants.ts
@@ -6,7 +6,6 @@ export const DOCUMENT_CLIENT = "DocumentClient";
 export const DYNAMODB_DOCUMENT = "DynamoDBDocument";
 export const DYNAMODB_DOCUMENT_CLIENT = [DYNAMODB, DOCUMENT_CLIENT].join(".");
 
-export const OBJECT_PROPERTY_TYPE_LIST = ["Property", "ObjectProperty"];
 export const FUNCTION_TYPE_LIST = [
   "FunctionDeclaration",
   "FunctionExpression",

--- a/src/transforms/v2-to-v3/modules/getRequireDeclaratorsWithObjectPattern.ts
+++ b/src/transforms/v2-to-v3/modules/getRequireDeclaratorsWithObjectPattern.ts
@@ -1,6 +1,5 @@
-import type { Collection, JSCodeshift, ObjectProperty, Property } from "jscodeshift";
+import type { Collection, JSCodeshift } from "jscodeshift";
 
-import { OBJECT_PROPERTY_TYPE_LIST } from "../config";
 import { getRequireDeclarators } from "./requireModule";
 
 export interface GetRequireDeclaratorsWithObjectPattern {
@@ -19,8 +18,9 @@ export const getRequireDeclaratorsWithObjectPattern = (
     }
     const { properties } = declarator.value.id;
     return properties.some((property) => {
-      if (!OBJECT_PROPERTY_TYPE_LIST.includes(property.type)) return false;
-      const propertyValue = (property as Property | ObjectProperty).value;
-      return propertyValue.type === "Identifier" && propertyValue.name === identifierName;
+      if (property.type !== "Property" && property.type !== "ObjectProperty") {
+        return false;
+      }
+      return property.value.type === "Identifier" && property.value.name === identifierName;
     });
   });

--- a/src/transforms/v2-to-v3/modules/objectPatternPropertyCompareFn.ts
+++ b/src/transforms/v2-to-v3/modules/objectPatternPropertyCompareFn.ts
@@ -7,8 +7,6 @@ import type {
   SpreadPropertyPattern,
 } from "jscodeshift";
 
-import { OBJECT_PROPERTY_TYPE_LIST } from "../config";
-
 export type ObjectPatternProperty =
   | Property
   | PropertyPattern
@@ -21,14 +19,14 @@ export const objectPatternPropertyCompareFn = (
   property1: ObjectPatternProperty,
   property2: ObjectPatternProperty
 ) => {
-  if (
-    OBJECT_PROPERTY_TYPE_LIST.includes(property1.type) &&
-    OBJECT_PROPERTY_TYPE_LIST.includes(property2.type)
-  ) {
-    const property1Key = (property1 as Property | ObjectProperty).key;
-    const property2Key = (property2 as Property | ObjectProperty).key;
-    if (property1Key.type === "Identifier" && property2Key.type === "Identifier")
-      return property1Key.name.localeCompare(property2Key.name);
+  if (property1.type !== "Property" && property1.type !== "ObjectProperty") {
+    return 0;
+  }
+  if (property2.type !== "Property" && property2.type !== "ObjectProperty") {
+    return 0;
+  }
+  if (property1.key.type === "Identifier" && property2.key.type === "Identifier") {
+    return property1.key.name.localeCompare(property2.key.name);
   }
   return 0;
 };

--- a/src/transforms/v2-to-v3/modules/requireModule/addNamedModule.ts
+++ b/src/transforms/v2-to-v3/modules/requireModule/addNamedModule.ts
@@ -1,6 +1,6 @@
-import type { Collection, JSCodeshift, ObjectPattern, ObjectProperty, Property } from "jscodeshift";
+import type { Collection, JSCodeshift, ObjectPattern } from "jscodeshift";
 
-import { OBJECT_PROPERTY_TYPE_LIST, PACKAGE_NAME } from "../../config";
+import { PACKAGE_NAME } from "../../config";
 import { objectPatternPropertyCompareFn } from "../objectPatternPropertyCompareFn";
 import { getRequireDeclarators } from "../requireModule";
 import type { ModulesOptions } from "../types";
@@ -30,13 +30,13 @@ export const addNamedModule = (
         (variableDeclarator) =>
           variableDeclarator.id.type === "ObjectPattern" &&
           variableDeclarator.id.properties.find((property) => {
-            if (!OBJECT_PROPERTY_TYPE_LIST.includes(property.type)) return false;
-            const key = (property as Property | ObjectProperty).key;
-            const value = (property as Property | ObjectProperty).value;
-            if (key.type !== "Identifier" || value.type !== "Identifier") {
+            if (property.type !== "Property" && property.type !== "ObjectProperty") {
               return false;
             }
-            return key.name === importedName && value.name === localName;
+            if (property.key.type !== "Identifier" || property.value.type !== "Identifier") {
+              return false;
+            }
+            return property.key.name === importedName && property.value.name === localName;
           })
       )
     ) {


### PR DESCRIPTION
### Issue

Feature introduced in TypeScript 5.4 https://devblogs.microsoft.com/typescript/announcing-typescript-5-4/#preserved-narrowing-in-closures-following-last-assignments

### Description

Removes type assertions for Property and ObjectProperty

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
