### PR TITLE
chore: remove unused simple-git-hooks config

### DIFF
--- a/simple-git-hooks.json
+++ b/simple-git-hooks.json
@@ -1,3 +1,0 @@
-{
-  "pre-commit": "yarn lint-staged"
-}


### PR DESCRIPTION
### Issue

The simple-git-hooks was moved to lefthook when switching from prettier+eslint to biome, but the configuration got left https://github.com/aws/aws-sdk-js-codemod/pull/886

### Description

Removes unused simple-git-hooks config

### Testing

N/A

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
