### PR TITLE
Use node 22.x `--experimental-strip-types` instead of tsx to run scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
   "scripts": {
     "build": "tsc",
     "format": "biome format --write",
-    "generate:map": "tsx scripts/generateClientTypesMap",
-    "generate:tests": "tsx scripts/generateNewClientTests",
+    "generate:map": "node --experimental-strip-types scripts/generateClientTypesMap/index.ts",
+    "generate:tests": "node --experimental-strip-types scripts/generateNewClientTests/index.ts",
     "lint": "biome lint --write",
     "release": "yarn build && changeset publish",
     "test": "vitest"

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "@types/jscodeshift": "^0.11.11",
     "@types/node": "^16.18.101",
     "aws-sdk": "2.1641.0",
-    "tsx": "^4.7.1",
     "typescript": "~5.5.2",
     "vitest": "~2.0.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1467,7 +1467,6 @@ __metadata:
     "@types/node": "npm:^16.18.101"
     aws-sdk: "npm:2.1641.0"
     jscodeshift: "npm:0.16.1"
-    tsx: "npm:^4.7.1"
     typescript: "npm:~5.5.2"
     vitest: "npm:~2.0.1"
   bin:
@@ -1901,7 +1900,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild@npm:^0.21.3, esbuild@npm:~0.21.5":
+"esbuild@npm:^0.21.3":
   version: 0.21.5
   resolution: "esbuild@npm:0.21.5"
   dependencies:
@@ -2274,15 +2273,6 @@ __metadata:
   version: 8.0.1
   resolution: "get-stream@npm:8.0.1"
   checksum: 10c0/5c2181e98202b9dae0bb4a849979291043e5892eb40312b47f0c22b9414fc9b28a3b6063d2375705eb24abc41ecf97894d9a51f64ff021511b504477b27b4290
-  languageName: node
-  linkType: hard
-
-"get-tsconfig@npm:^4.7.5":
-  version: 4.7.6
-  resolution: "get-tsconfig@npm:4.7.6"
-  dependencies:
-    resolve-pkg-maps: "npm:^1.0.0"
-  checksum: 10c0/2240e1b13e996dfbb947d177f422f83d09d1f93c9ce16959ebb3c2bdf8bdf4f04f98eba043859172da1685f9c7071091f0acfa964ebbe4780394d83b7dc3f58a
   languageName: node
   linkType: hard
 
@@ -3524,13 +3514,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve-pkg-maps@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "resolve-pkg-maps@npm:1.0.0"
-  checksum: 10c0/fb8f7bbe2ca281a73b7ef423a1cbc786fb244bd7a95cbe5c3fba25b27d327150beca8ba02f622baea65919a57e061eb5005204daa5f93ed590d9b77463a567ab
-  languageName: node
-  linkType: hard
-
 "retry@npm:^0.12.0":
   version: 0.12.0
   resolution: "retry@npm:0.12.0"
@@ -4025,22 +4008,6 @@ __metadata:
   version: 2.6.3
   resolution: "tslib@npm:2.6.3"
   checksum: 10c0/2598aef53d9dbe711af75522464b2104724d6467b26a60f2bdac8297d2b5f1f6b86a71f61717384aa8fd897240467aaa7bcc36a0700a0faf751293d1331db39a
-  languageName: node
-  linkType: hard
-
-"tsx@npm:^4.7.1":
-  version: 4.16.3
-  resolution: "tsx@npm:4.16.3"
-  dependencies:
-    esbuild: "npm:~0.21.5"
-    fsevents: "npm:~2.3.3"
-    get-tsconfig: "npm:^4.7.5"
-  dependenciesMeta:
-    fsevents:
-      optional: true
-  bin:
-    tsx: dist/cli.mjs
-  checksum: 10c0/bb7e5fa8c5fbb3f7f4a1de3142d617139158cbfa5bbb02927fe2bdf792ac7202aa1b63e33a31fa43050fe9666b15c20f516947ea938cb327e926933fd2c56ee4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Issue

https://nodejs.org/en/blog/release/v22.6.0#experimental-typescript-support-via-strip-types

### Description

Attempts to use node 22.x `--experimental-strip-types` instead of tsx to run scripts

### Testing

Discontinued, since imports require `*.ts` extension

```console
$ yarn generate:tests
(node:32889) ExperimentalWarning: Type Stripping is an experimental feature and might change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
(node:32889) [MODULE_TYPELESS_PACKAGE_JSON] Warning: file:///Users/trivikram/workspace/aws-sdk-js-codemod/scripts/generateNewClientTests/index.ts parsed as an ES module because module syntax was detected; to avoid the performance penalty of syntax detection, add "type": "module" to /Users/trivikram/workspace/aws-sdk-js-codemod/package.json
node:internal/modules/esm/resolve:257
    throw new ERR_MODULE_NOT_FOUND(
          ^

Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/Users/trivikram/workspace/aws-sdk-js-codemod/scripts/generateNewClientTests/getGlobalImportEqualsInput' imported from /Users/trivikram/workspace/aws-sdk-js-codemod/scripts/generateNewClientTests/index.ts
    at finalizeResolution (node:internal/modules/esm/resolve:257:11)
    at moduleResolve (node:internal/modules/esm/resolve:914:10)
    at defaultResolve (node:internal/modules/esm/resolve:1039:11)
    at ModuleLoader.defaultResolve (node:internal/modules/esm/loader:554:12)
    at ModuleLoader.resolve (node:internal/modules/esm/loader:523:25)
    at ModuleLoader.getModuleJob (node:internal/modules/esm/loader:246:38)
    at ModuleJob._link (node:internal/modules/esm/module_job:126:49) {
  code: 'ERR_MODULE_NOT_FOUND',
  url: 'file:///Users/trivikram/workspace/aws-sdk-js-codemod/scripts/generateNewClientTests/getGlobalImportEqualsInput'
}

Node.js v22.6.0
```

It can be retried if codemod is converted to ESM in future, and when the strip-types support gets stable.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
