### PR TITLE
Bump jscodeshift to 17.0.0

### DIFF
--- a/.changeset/funny-spies-tan.md
+++ b/.changeset/funny-spies-tan.md
@@ -1,0 +1,5 @@
+---
+"aws-sdk-js-codemod": minor
+---
+
+Bump jscodeshift to 17.0.0

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "test": "vitest"
   },
   "dependencies": {
-    "jscodeshift": "0.16.1"
+    "jscodeshift": "17.0.0"
   },
   "devDependencies": {
     "@biomejs/biome": "1.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1390,7 +1390,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ansi-styles@npm:^4.0.0, ansi-styles@npm:^4.1.0":
+"ansi-styles@npm:^4.0.0":
   version: 4.3.0
   resolution: "ansi-styles@npm:4.3.0"
   dependencies:
@@ -1466,7 +1466,7 @@ __metadata:
     "@types/jscodeshift": "npm:^0.11.11"
     "@types/node": "npm:^16.18.101"
     aws-sdk: "npm:2.1641.0"
-    jscodeshift: "npm:0.16.1"
+    jscodeshift: "npm:17.0.0"
     tsx: "npm:^4.7.1"
     typescript: "npm:~5.5.2"
     vitest: "npm:~2.0.1"
@@ -1644,16 +1644,6 @@ __metadata:
     escape-string-regexp: "npm:^1.0.5"
     supports-color: "npm:^5.3.0"
   checksum: 10c0/e6543f02ec877732e3a2d1c3c3323ddb4d39fbab687c23f526e25bd4c6a9bf3b83a696e8c769d078e04e5754921648f7821b2a2acfd16c550435fd630026e073
-  languageName: node
-  linkType: hard
-
-"chalk@npm:^4.1.2":
-  version: 4.1.2
-  resolution: "chalk@npm:4.1.2"
-  dependencies:
-    ansi-styles: "npm:^4.1.0"
-    supports-color: "npm:^7.1.0"
-  checksum: 10c0/4a3fef5cc34975c898ffe77141450f679721df9dde00f6c304353fa9c8b571929123b26a0e4617bde5018977eb655b31970c297b91b63ee83bb82aeb04666880
   languageName: node
   linkType: hard
 
@@ -2369,13 +2359,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"has-flag@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "has-flag@npm:4.0.0"
-  checksum: 10c0/2e789c61b7888d66993e14e8331449e525ef42aac53c627cc53d1c3334e768bcb6abdc4f5f0de1478a25beec6f0bd62c7549058b7ac53e924040d4f301f02fd1
-  languageName: node
-  linkType: hard
-
 "has-property-descriptors@npm:^1.0.2":
   version: 1.0.2
   resolution: "has-property-descriptors@npm:1.0.2"
@@ -2716,9 +2699,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jscodeshift@npm:0.16.1":
-  version: 0.16.1
-  resolution: "jscodeshift@npm:0.16.1"
+"jscodeshift@npm:17.0.0":
+  version: 17.0.0
+  resolution: "jscodeshift@npm:17.0.0"
   dependencies:
     "@babel/core": "npm:^7.24.7"
     "@babel/parser": "npm:^7.24.7"
@@ -2730,12 +2713,11 @@ __metadata:
     "@babel/preset-flow": "npm:^7.24.7"
     "@babel/preset-typescript": "npm:^7.24.7"
     "@babel/register": "npm:^7.24.6"
-    chalk: "npm:^4.1.2"
     flow-parser: "npm:0.*"
     graceful-fs: "npm:^4.2.4"
     micromatch: "npm:^4.0.7"
     neo-async: "npm:^2.5.0"
-    node-dir: "npm:^0.1.17"
+    picocolors: "npm:^1.0.1"
     recast: "npm:^0.23.9"
     temp: "npm:^0.9.4"
     write-file-atomic: "npm:^5.0.1"
@@ -2746,7 +2728,7 @@ __metadata:
       optional: true
   bin:
     jscodeshift: bin/jscodeshift.js
-  checksum: 10c0/6025dbb223499a650b6f07e5ed89c82ca5ba1fe4b379d6b87ce3ed39b590d04d1c80f9a79ce47445415b871ef714260b550343affcfa745d3d6e4eef6dd1006d
+  checksum: 10c0/9a5ae1b4320edf25bf78540306b7439e1e9ca3a48bd58ce65c18d8c52d8685b3fd1931c5f8cbb41fc1644a37794d432ca3e85a4c86d4f1b8d903b05d2c38407c
   languageName: node
   linkType: hard
 
@@ -2939,7 +2921,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:^3.0.2, minimatch@npm:^3.1.1":
+"minimatch@npm:^3.1.1":
   version: 3.1.2
   resolution: "minimatch@npm:3.1.2"
   dependencies:
@@ -3102,15 +3084,6 @@ __metadata:
   version: 2.6.2
   resolution: "neo-async@npm:2.6.2"
   checksum: 10c0/c2f5a604a54a8ec5438a342e1f356dff4bc33ccccdb6dc668d94fe8e5eccfc9d2c2eea6064b0967a767ba63b33763f51ccf2cd2441b461a7322656c1f06b3f5d
-  languageName: node
-  linkType: hard
-
-"node-dir@npm:^0.1.17":
-  version: 0.1.17
-  resolution: "node-dir@npm:0.1.17"
-  dependencies:
-    minimatch: "npm:^3.0.2"
-  checksum: 10c0/16222e871708c405079ff8122d4a7e1d522c5b90fc8f12b3112140af871cfc70128c376e845dcd0044c625db0d2efebd2d852414599d240564db61d53402b4c1
   languageName: node
   linkType: hard
 
@@ -3918,15 +3891,6 @@ __metadata:
   dependencies:
     has-flag: "npm:^3.0.0"
   checksum: 10c0/6ae5ff319bfbb021f8a86da8ea1f8db52fac8bd4d499492e30ec17095b58af11f0c55f8577390a749b1c4dde691b6a0315dab78f5f54c9b3d83f8fb5905c1c05
-  languageName: node
-  linkType: hard
-
-"supports-color@npm:^7.1.0":
-  version: 7.2.0
-  resolution: "supports-color@npm:7.2.0"
-  dependencies:
-    has-flag: "npm:^4.0.0"
-  checksum: 10c0/afb4c88521b8b136b5f5f95160c98dee7243dc79d5432db7efc27efb219385bbc7d9427398e43dd6cc730a0f87d5085ce1652af7efbe391327bc0a7d0f7fc124
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Issue

Refs: https://github.com/facebook/jscodeshift/releases/tag/v17.0.0

### Description

Bumps jscodeshift to 17.0.0

There are no breaking changes on major version bump.
The project just switched from unstable versions to stable versions
```console
$ npm view jscodeshift time --json | tail -n5
  "0.15.2": "2024-02-22T05:06:25.548Z",
  "0.16.0": "2024-06-18T17:59:56.956Z",
  "0.16.1": "2024-06-25T17:07:44.012Z",
  "17.0.0": "2024-08-06T19:56:53.652Z"
}
```

This is similar to when react switched from `0.14.x` to `15.x` in the past
```console
$ npm view react time --json | grep '1[45]\.' | sed -n '14,20p'
  "0.14.6": "2016-01-06T23:52:45.571Z",
  "0.15.0-alpha.1": "2016-01-21T04:16:30.061Z",
  "0.14.7": "2016-01-28T19:59:29.509Z",
  "15.0.0-rc.1": "2016-03-08T01:07:27.078Z",
  "15.0.0-rc.2": "2016-03-16T22:19:35.759Z",
  "0.14.8": "2016-03-29T16:19:44.344Z",
  "15.0.0": "2016-04-07T21:25:42.928Z",
```

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
