### PR TITLE
chore(deps-dev): bump yarn to 4.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   "engines": {
     "node": ">=16.0.0"
   },
-  "packageManager": "yarn@4.4.0",
+  "packageManager": "yarn@4.5.0",
   "publishConfig": {
     "provenance": true
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4271,11 +4271,11 @@ __metadata:
 
 "typescript@patch:typescript@npm%3A~5.6.2#optional!builtin<compat/typescript>":
   version: 5.6.2
-  resolution: "typescript@patch:typescript@npm%3A5.6.2#optional!builtin<compat/typescript>::version=5.6.2&hash=74658d"
+  resolution: "typescript@patch:typescript@npm%3A5.6.2#optional!builtin<compat/typescript>::version=5.6.2&hash=8c6c40"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/e6c1662e4852e22fe4bbdca471dca3e3edc74f6f1df043135c44a18a7902037023ccb0abdfb754595ca9028df8920f2f8492c00fc3cbb4309079aae8b7de71cd
+  checksum: 10c0/94eb47e130d3edd964b76da85975601dcb3604b0c848a36f63ac448d0104e93819d94c8bdf6b07c00120f2ce9c05256b8b6092d23cf5cf1c6fa911159e4d572f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Issue

https://github.com/yarnpkg/berry/releases/tag/%40yarnpkg/cli/4.5.0

### Description

Bumps yarn to 4.5.0

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
