### PR TITLE
Run unit tests on Node.js 22.x

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 20.x]
+        node-version: [18.x, 20.x, 22.x]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
### Issue

Active LTS for Node.js 22.x will start on 2024-10-29

### Description

Run unit tests on Node.js 22.x

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
