### PR TITLE
Fix package name of MemoryDB client

### DIFF
--- a/.changeset/weak-poems-attack.md
+++ b/.changeset/weak-poems-attack.md
@@ -1,0 +1,5 @@
+---
+"aws-sdk-js-codemod": patch
+---
+
+Fix package name of MemoryDB client

--- a/src/transforms/v2-to-v3/__fixtures__/new-client/global-import.output.js
+++ b/src/transforms/v2-to-v3/__fixtures__/new-client/global-import.output.js
@@ -238,7 +238,7 @@ import { MediaStore } from "@aws-sdk/client-mediastore";
 import { MediaStoreData } from "@aws-sdk/client-mediastore-data";
 import { MediaTailor } from "@aws-sdk/client-mediatailor";
 import { MedicalImaging } from "@aws-sdk/client-medical-imaging";
-import { MemoryDB } from "@aws-sdk/client-memory-db";
+import { MemoryDB } from "@aws-sdk/client-memorydb";
 import { Mgn } from "@aws-sdk/client-mgn";
 import { MigrationHub } from "@aws-sdk/client-migration-hub";
 import { MigrationHubRefactorSpaces } from "@aws-sdk/client-migration-hub-refactor-spaces";

--- a/src/transforms/v2-to-v3/config/CLIENT_PACKAGE_NAMES_MAP.ts
+++ b/src/transforms/v2-to-v3/config/CLIENT_PACKAGE_NAMES_MAP.ts
@@ -104,6 +104,7 @@ export const CLIENT_PACKAGE_NAMES_MAP: Record<string, string> = {
   ManagedBlockchain: "client-managedblockchain",
   ManagedBlockchainQuery: "client-managedblockchain-query",
   MediaPackageV2: "client-mediapackagev2",
+  MemoryDB: "client-memorydb",
   MigrationHubConfig: "client-migrationhub-config",
   MigrationHubRefactorSpaces: "client-migration-hub-refactor-spaces",
   NetworkManager: "client-networkmanager",


### PR DESCRIPTION
### Issue

Fixes: https://github.com/aws/aws-sdk-js-codemod/issues/949

### Description

Fixes package name of MemoryDB client correctly to `@aws-sdk/client-memorydb`

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
