### PR TITLE
Remove corepack from GitHub workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,8 +13,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: corepack
-        run: corepack enable
       - uses: biomejs/setup-biome@v2
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -16,8 +16,6 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v4
-      - name: corepack
-        run: corepack enable
       - uses: actions/setup-node@v4
         with:
           cache: "npm"


### PR DESCRIPTION
### Issue

Missed in https://github.com/aws/aws-sdk-js-codemod/pull/948

### Description

We don't need to enable corepack, since we now use npm with devEngines for installation

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
