### PR TITLE
Add prepublishOnly script to test changed package names exist on npm

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aws-sdk-js-codemod",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aws-sdk-js-codemod",
-      "version": "2.4.1",
+      "version": "2.4.2",
       "license": "MIT-0",
       "dependencies": {
         "jscodeshift": "17.1.1"

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "generate:map": "tsx scripts/generateClientTypesMap",
     "generate:tests": "tsx scripts/generateNewClientTests",
     "lint": "biome lint --write",
+    "prepublishOnly": "tsx scripts/testChangedPackageNames",
     "release": "npm run build && changeset publish",
     "test": "vitest"
   },

--- a/scripts/testChangedPackageNames/index.ts
+++ b/scripts/testChangedPackageNames/index.ts
@@ -1,0 +1,29 @@
+import { exec } from "node:child_process";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import { CLIENT_PACKAGE_NAMES_MAP as PACKAGE_NAMES_MAP_TO_PUBLISH } from "../../src/transforms/v2-to-v3/config";
+
+const execAsync = promisify(exec);
+
+(async () => {
+  // Create temporary directory
+  const tempDir = await mkdtemp(join(tmpdir(), "testChangedPackageNames-"));
+  await execAsync("npm install aws-sdk-js-codemod@latest", { cwd: tempDir });
+
+  const { CLIENT_PACKAGE_NAMES_MAP: PACKAGE_NAMES_MAP_LATEST } = await import(
+    join(tempDir, "node_modules/aws-sdk-js-codemod/dist/transforms/v2-to-v3/config")
+  );
+
+  const changedPackageNames = Object.keys(PACKAGE_NAMES_MAP_TO_PUBLISH)
+    .filter((key) => PACKAGE_NAMES_MAP_TO_PUBLISH[key] !== PACKAGE_NAMES_MAP_LATEST[key])
+    .map((key) => PACKAGE_NAMES_MAP_TO_PUBLISH[key]);
+
+  console.log(`Changed package names: ${changedPackageNames.join(", ")}`);
+  for (const packageName of changedPackageNames) {
+    const npmPackageName = `@aws-sdk/${packageName}`;
+    await execAsync(`npm show ${npmPackageName} version`);
+    console.log(`${npmPackageName} exists`);
+  }
+})();


### PR DESCRIPTION
### Issue

Fixes: https://github.com/aws/aws-sdk-js-codemod/issues/950

### Description

Add prepublish script to test changed package names exist on npm

### Testing

CI

Verified that changed package names from https://github.com/aws/aws-sdk-js-codemod/pull/962 are tested
```console
$ npm run prepublishOnly

> aws-sdk-js-codemod@2.4.2 prepublish
> tsx scripts/testChangedPackageNames

Changed package names: client-sagemaker-a2i-runtime, client-eks-auth
@aws-sdk/client-sagemaker-a2i-runtime exists
@aws-sdk/client-eks-auth exists
```

Verified that script fails if the package doesn't exist on npm
```console
$ git diff | head
diff --git a/src/transforms/v2-to-v3/config/CLIENT_PACKAGE_NAMES_MAP.ts b/src/transforms/v2-to-v3/config/CLIENT_PACKAGE_NAMES_MAP.ts
index 2b7d087..bdf20bf 100644
--- a/src/transforms/v2-to-v3/config/CLIENT_PACKAGE_NAMES_MAP.ts
+++ b/src/transforms/v2-to-v3/config/CLIENT_PACKAGE_NAMES_MAP.ts
@@ -5,7 +5,7 @@ export const CLIENT_PACKAGE_NAMES_MAP: Record<string, string> = {
   ...CLIENT_NAMES.reduce((acc: Record<string, string>, name) => {
     acc[name] = `client-${name.replace(/([a-z])([A-Z])/g, "$1-$2").toLowerCase()}`
       .replace("-chime-sdk", "-chime-sdk-")
-      .replace("client-amplify-", "client-amplify")
+      .replace("client-amplify-", "client-amplify2")

$ npm run prepublishOnly

> aws-sdk-js-codemod@2.4.2 prepublishOnly
> tsx scripts/testChangedPackageNames

Changed package names: client-amplify2backend, client-amplify2uibuilder, client-sagemaker-a2i-runtime, client-eks-auth
node:internal/errors:984
  const err = new Error(message);
              ^

Error: Command failed: npm show @aws-sdk/client-amplify2backend version
npm error code E404
npm error 404 Not Found - GET https://registry.npmjs.org/@aws-sdk%2fclient-amplify2backend - Not found
npm error 404
npm error 404  '@aws-sdk/client-amplify2backend@*' is not in this registry.
npm error 404
npm error 404 Note that you can also install from a
npm error 404 tarball, folder, http url, or git url.
npm error A complete log of this run can be found in: /Users/trivikram/.npm/_logs/2024-11-05T04_30_58_518Z-debug-0.log

    at genericNodeError (node:internal/errors:984:15)
    at wrappedFn (node:internal/errors:538:14)
    at ChildProcess.exithandler (node:child_process:422:12)
    at ChildProcess.emit (node:events:519:28)
    at maybeClose (node:internal/child_process:1105:16)
    at ChildProcess._handle.onexit (node:internal/child_process:305:5) {
  code: 1,
  killed: false,
  signal: null,
  cmd: 'npm show @aws-sdk/client-amplify2backend version',
  stdout: '',
  stderr: 'npm error code E404\n' +
    'npm error 404 Not Found - GET https://registry.npmjs.org/@aws-sdk%2fclient-amplify2backend - Not found\n' +
    'npm error 404\n' +
    "npm error 404  '@aws-sdk/client-amplify2backend@*' is not in this registry.\n" +
    'npm error 404\n' +
    'npm error 404 Note that you can also install from a\n' +
    'npm error 404 tarball, folder, http url, or git url.\n' +
    'npm error A complete log of this run can be found in: /Users/trivikram/.npm/_logs/2024-11-05T04_30_58_518Z-debug-0.log\n'
}

Node.js v20.18.0
```

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
