### PR TITLE
Update lockfile before posting changeset PR

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "generate:tests": "tsx scripts/generateNewClientTests",
     "lint": "biome lint --write",
     "prepublishOnly": "tsx scripts/testChangedPackageNames",
-    "release": "npm run build && changeset publish",
+    "prerelease": "npm run build && changeset version && npm i --lockfile-only",
+    "release": "changeset publish",
     "test": "vitest"
   },
   "dependencies": {


### PR DESCRIPTION
### Issue

Changeset does not update lockfile version https://github.com/changesets/changesets/issues/1139
* The version is lockfile was updated to `v2.4.2` in PR https://github.com/aws/aws-sdk-js-codemod/pull/964
* The latest PR https://github.com/aws/aws-sdk-js-codemod/pull/963 does not update version in package-lock (it'll updated after this PR is merged)

### Description

Updates lockfile before posting changeset PR

### Testing

Verified that package-lock.json is updated.
```console
$ npm run prerelease
...

$ git status
On branch changeset-lockfile-version
Changes not staged for commit:
  (use "git add/rm <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
        deleted:    .changeset/mean-sheep-refuse.md
        modified:   CHANGELOG.md
        modified:   package-lock.json
        modified:   package.json

$ git diff package-lock.json | head
diff --git a/package-lock.json b/package-lock.json
index abe4451..56c5632 100644
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aws-sdk-js-codemod",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "lockfileVersion": 3,
```

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
