### PR TITLE
Move testChangedPackageNames prior to changeset publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,8 +38,7 @@
     "generate:map": "tsx scripts/generateClientTypesMap",
     "generate:tests": "tsx scripts/generateNewClientTests",
     "lint": "biome lint --write",
-    "prepublishOnly": "tsx scripts/testChangedPackageNames",
-    "release": "npm run build && changeset publish",
+    "release": "tsx scripts/testChangedPackageNames && npm run build && changeset publish",
     "test": "vitest",
     "version": "changeset version && npm i --package-lock-only"
   },


### PR DESCRIPTION
### Issue

The testChangedPackageNames script was not run on publish
```console
No changesets found. Attempting to publish any unpublished packages to npm
No user .npmrc file found, creating one
/usr/local/bin/npm run release

> aws-sdk-js-codemod@2.4.3 release
> npm run build && changeset publish
```
https://github.com/aws/aws-sdk-js-codemod/actions/runs/11678054032/job/32516955805

This happens as changesets does not run pre and post publish scripts https://github.com/changesets/changesets/issues/982

### Description

Move testChangedPackageNames prior to changeset publish

### Testing

N/A

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
