### PR TITLE
chore(deps-dev): bump typescript to 5.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@types/node": "^16.18.101",
         "aws-sdk": "2.1692.0",
         "tsx": "^4.7.1",
-        "typescript": "~5.6.2",
+        "typescript": "~5.7.2",
         "vitest": "~2.0.1"
       },
       "engines": {
@@ -4310,9 +4310,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.6.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
-      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
+      "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@types/node": "^16.18.101",
     "aws-sdk": "2.1692.0",
     "tsx": "^4.7.1",
-    "typescript": "~5.6.2",
+    "typescript": "~5.7.2",
     "vitest": "~2.0.1"
   },
   "engines": {


### PR DESCRIPTION
### Issue

https://devblogs.microsoft.com/typescript/announcing-typescript-5-7/

### Description

Bumps typescript to 5.7

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
