### PR TITLE
chore(ci): remove redundant corepack enable

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,13 +13,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      - name: corepack
+        run: npm i -g corepack
       - uses: biomejs/setup-biome@v2
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
           cache: "yarn"
-      - name: corepack
-        run: npm i -g corepack
       - name: install
         run: yarn
       - name: lint+format

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,13 +13,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: corepack
-        run: npm i -g corepack
       - uses: biomejs/setup-biome@v2
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
           cache: "yarn"
+      - name: corepack
+        run: npm i -g corepack
       - name: install
         run: yarn
       - name: lint+format

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: corepack
-        run: npm install -g corepack && corepack enable
+        run: npm i -g corepack
       - uses: biomejs/setup-biome@v2
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: corepack
-        run: npm install -g corepack && corepack enable
+        run: npm i -g corepack
       - uses: actions/setup-node@v4
         with:
           cache: "yarn"

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -16,14 +16,13 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v4
+      - name: corepack
+        run: npm i -g corepack
       - uses: actions/setup-node@v4
         with:
           cache: "yarn"
 
-      - name: corepack
-        run: npm i -g corepack
-      - name: install
-        run: yarn
+      - run: yarn
 
       - name: Create Release Pull Request or Publish to npm
         id: changesets

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -16,13 +16,14 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v4
-      - name: corepack
-        run: npm i -g corepack
       - uses: actions/setup-node@v4
         with:
           cache: "yarn"
 
-      - run: yarn
+      - name: corepack
+        run: npm i -g corepack
+      - name: install
+        run: yarn
 
       - name: Create Release Pull Request or Publish to npm
         id: changesets


### PR DESCRIPTION
### Issue

The command `corepack enable` is not required to be run for after globally installing corepack
https://www.github.com/nodejs/corepack/issues/104#issuecomment-2746172451

### Description

Removes redundant command corepack enable

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
