### PR TITLE
chore(scripts): replace biome format+lint with check

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,10 +34,9 @@
   },
   "scripts": {
     "build": "tsc",
-    "format": "biome format --write",
+    "check": "biome check --write",
     "generate:map": "tsx scripts/generateClientTypesMap",
     "generate:tests": "tsx scripts/generateNewClientTests",
-    "lint": "biome lint --write",
     "release": "tsx scripts/testUpdatedIdentifiers && yarn build && changeset publish",
     "test": "node --import tsx --test src/**/*.spec.ts"
   },


### PR DESCRIPTION
### Issue

https://biomejs.dev/reference/cli/#biome-check

### Description

Replace biome format and lint commands with check

### Testing

#### Before

Two commands need to run for formatting and linting.
Neither of them did import sorting.
```console
$ yarn format
Formatted 196 files in 111ms. No fixes applied.

$ yarn lint
Checked 196 files in 154ms. No fixes applied.
```

#### After

One command for formatting, linting and import sorting.
```console
$ yarn check
Checked 196 files in 249ms. No fixes applied.
```

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
