### PR TITLE
chore(ci): remove biomejs/setup-biome

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,6 @@ jobs:
       - uses: actions/checkout@v4
       - name: corepack
         run: npm i -g corepack
-      - uses: biomejs/setup-biome@v2
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
@@ -23,7 +22,7 @@ jobs:
       - name: install
         run: yarn
       - name: lint+format
-        run: biome ci
+        run: yarn ci
       - name: build
         run: yarn build
       - name: test

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "scripts": {
     "build": "tsc",
     "check": "biome check --write",
+    "ci": "biome ci",
     "generate:map": "tsx scripts/generateClientTypesMap",
     "generate:tests": "tsx scripts/generateNewClientTests",
     "release": "tsx scripts/testUpdatedIdentifiers && yarn build && changeset publish",


### PR DESCRIPTION
### Issue

https://github.com/aws/aws-sdk-js-codemod/pull/980#issuecomment-2753136952

### Description

Remove biomejs/setup-biome from actions workflow.
The biome dependency is already available as part of installation, and `ci` command can be called.

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
