### PR TITLE
chore: drop support for Node.js 16.x

### DIFF
--- a/.changeset/hot-toes-travel.md
+++ b/.changeset/hot-toes-travel.md
@@ -1,0 +1,5 @@
+---
+"aws-sdk-js-codemod": major
+---
+
+Drop support for Node.js 16.x

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   "devDependencies": {
     "@biomejs/biome": "1.9.0",
     "@changesets/cli": "^2.27.1",
-    "@tsconfig/node16": "^16.1.3",
+    "@tsconfig/node18": "^18.2.4",
     "@types/jscodeshift": "^0.12.0",
     "@types/node": "^16.18.101",
     "aws-sdk": "2.1692.0",
@@ -55,7 +55,7 @@
     "typescript": "~5.7.2"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "devEngines": {
     "packageManager": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node16/tsconfig.json",
+  "extends": "@tsconfig/node18/tsconfig.json",
   "compilerOptions": {
     "outDir": "dist",
     "resolveJsonModule": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1076,10 +1076,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tsconfig/node16@npm:^16.1.3":
-  version: 16.1.3
-  resolution: "@tsconfig/node16@npm:16.1.3"
-  checksum: 10c0/4349c513719c5e1ef1995cc0c09d6099761ec0f3814a7165bf0622dfa76b2cc8580fac022bf1863f7eb6e34ced280c6d2dfb3750b6e1e2c5b96cb4e7e4004f04
+"@tsconfig/node18@npm:^18.2.4":
+  version: 18.2.4
+  resolution: "@tsconfig/node18@npm:18.2.4"
+  checksum: 10c0/cdfd17f212660374eb2765cd5907b2252e43cfa2623cd52307a49f004327ef49bbe7d53c78b0aca57f33e9a5cb0d7d2eb5ded9be1235e6212f65c9f0699322b6
   languageName: node
   linkType: hard
 
@@ -1207,7 +1207,7 @@ __metadata:
   dependencies:
     "@biomejs/biome": "npm:1.9.0"
     "@changesets/cli": "npm:^2.27.1"
-    "@tsconfig/node16": "npm:^16.1.3"
+    "@tsconfig/node18": "npm:^18.2.4"
     "@types/jscodeshift": "npm:^0.12.0"
     "@types/node": "npm:^16.18.101"
     aws-sdk: "npm:2.1692.0"


### PR DESCRIPTION
### Issue

JS SDK dropped support for Node.js 16.x in https://github.com/aws/aws-sdk-js-v3/pull/6775

### Description

Drop support for Node.js 16.x

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
