### PR TITLE
chore(deps): bump jscodeshift to v17.3.0

### DIFF
--- a/.changeset/soft-bottles-sort.md
+++ b/.changeset/soft-bottles-sort.md
@@ -1,0 +1,5 @@
+---
+"aws-sdk-js-codemod": minor
+---
+
+Bumps jscodeshift to v17.3.0

--- a/package.json
+++ b/package.json
@@ -42,13 +42,13 @@
     "test": "node --import tsx --test src/**/*.spec.ts"
   },
   "dependencies": {
-    "jscodeshift": "17.1.1"
+    "jscodeshift": "17.3.0"
   },
   "devDependencies": {
     "@biomejs/biome": "1.9.0",
     "@changesets/cli": "^2.27.1",
     "@tsconfig/node18": "^18.2.4",
-    "@types/jscodeshift": "^0.12.0",
+    "@types/jscodeshift": "^17.3.0",
     "@types/node": "^18.19.112",
     "aws-sdk": "2.1692.0",
     "tsx": "^4.7.1",

--- a/src/transforms/v2-to-v3/modules/importEqualsModule/getImportSpecifiers.ts
+++ b/src/transforms/v2-to-v3/modules/importEqualsModule/getImportSpecifiers.ts
@@ -10,7 +10,11 @@ export const getImportSpecifiers = (
   const importSpecifiers = new Set<ImportSpecifierType>();
 
   getImportEqualsDeclarations(j, source, path).forEach((importEqualsDeclaration) => {
-    importSpecifiers.add({ localName: importEqualsDeclaration.value.id.name });
+    const localName = importEqualsDeclaration.value.id.name;
+    if (typeof localName !== "string") {
+      throw new Error("Please report your use case on https://github.com/aws/aws-sdk-js-codemod");
+    }
+    importSpecifiers.add({ localName });
   });
 
   return Array.from(importSpecifiers);

--- a/src/transforms/v2-to-v3/modules/importEqualsModule/removeImportEquals.ts
+++ b/src/transforms/v2-to-v3/modules/importEqualsModule/removeImportEquals.ts
@@ -8,6 +8,9 @@ const isAnotherSpecifier = (j: JSCodeshift, source: Collection<unknown>, localNa
 export const removeImportEquals = (j: JSCodeshift, source: Collection<unknown>) =>
   getImportEqualsDeclarations(j, source).forEach((importEqualsDeclaration) => {
     const localName = importEqualsDeclaration.value.id.name;
+    if (typeof localName !== "string") {
+      throw new Error("Please report your use case on https://github.com/aws/aws-sdk-js-codemod");
+    }
     const identifiers = source.find(j.Identifier, { name: localName });
 
     // Either the identifier is the only occurence on the page.

--- a/src/transforms/v2-to-v3/modules/importModule/getImportSpecifiers.ts
+++ b/src/transforms/v2-to-v3/modules/importModule/getImportSpecifiers.ts
@@ -15,16 +15,28 @@ export const getImportSpecifiers = (
       switch (specifier.type) {
         case "ImportSpecifier": {
           const importedName = specifier.imported.name;
+          const localName = specifier.local?.name;
+          if (typeof importedName !== "string" || (localName && typeof localName !== "string")) {
+            throw new Error(
+              "Please report your use case on https://github.com/aws/aws-sdk-js-codemod"
+            );
+          }
           importSpecifiers.add({
             importedName,
-            localName: specifier.local?.name || importedName,
+            localName: localName || importedName,
           });
           break;
         }
         case "ImportNamespaceSpecifier":
         case "ImportDefaultSpecifier": {
           if (specifier.local) {
-            importSpecifiers.add({ localName: specifier.local.name });
+            const localName = specifier.local.name;
+            if (typeof localName !== "string") {
+              throw new Error(
+                "Please report your use case on https://github.com/aws/aws-sdk-js-codemod"
+              );
+            }
+            importSpecifiers.add({ localName });
           }
           break;
         }

--- a/src/transforms/v2-to-v3/modules/importModule/removeImport.ts
+++ b/src/transforms/v2-to-v3/modules/importModule/removeImport.ts
@@ -22,6 +22,11 @@ export const removeImport = (j: JSCodeshift, source: Collection<unknown>) =>
         if (!localName) {
           return true;
         }
+        if (typeof localName !== "string") {
+          throw new Error(
+            "Please report your use case on https://github.com/aws/aws-sdk-js-codemod"
+          );
+        }
         const identifiers = source.find(j.Identifier, { name: localName });
         const importedName = specifier.type === "ImportSpecifier" && specifier.imported?.name;
 

--- a/src/transforms/v2-to-v3/modules/importSpecifierCompareFn.ts
+++ b/src/transforms/v2-to-v3/modules/importSpecifierCompareFn.ts
@@ -9,25 +9,42 @@ export const importSpecifierCompareFn = (
   specifier2: ImportSpecifier | ImportDefaultSpecifier | ImportNamespaceSpecifier
 ) => {
   if (specifier1.type === "ImportSpecifier" && specifier2.type === "ImportSpecifier") {
-    return specifier1.imported.name.localeCompare(specifier2.imported.name);
+    const specifier1ImportedName = specifier1.imported.name;
+    const specifier2ImportedName = specifier2.imported.name;
+    if (typeof specifier1ImportedName !== "string" || typeof specifier2ImportedName !== "string") {
+      throw new Error("Please report your use case on https://github.com/aws/aws-sdk-js-codemod");
+    }
+    return specifier1ImportedName.localeCompare(specifier2ImportedName);
   }
 
   if (
     specifier1.type === "ImportDefaultSpecifier" &&
     specifier2.type === "ImportDefaultSpecifier"
   ) {
-    if (specifier1.local && specifier2.local)
-      return specifier1.local.name.localeCompare(specifier2.local.name);
-    return 0;
+    if (!specifier1.local || !specifier2.local) {
+      return 0;
+    }
+    const specifier1LocalName = specifier1.local.name;
+    const specifier2LocalName = specifier2.local.name;
+    if (typeof specifier1LocalName !== "string" || typeof specifier2LocalName !== "string") {
+      throw new Error("Please report your use case on https://github.com/aws/aws-sdk-js-codemod");
+    }
+    return specifier1LocalName.localeCompare(specifier2LocalName);
   }
 
   if (
     specifier1.type === "ImportNamespaceSpecifier" &&
     specifier2.type === "ImportNamespaceSpecifier"
   ) {
-    if (specifier1.local && specifier2.local)
-      return specifier1.local.name.localeCompare(specifier2.local.name);
-    return 0;
+    if (!specifier1.local || !specifier2.local) {
+      return 0;
+    }
+    const specifier1LocalName = specifier1.local.name;
+    const specifier2LocalName = specifier2.local.name;
+    if (typeof specifier1LocalName !== "string" || typeof specifier2LocalName !== "string") {
+      throw new Error("Please report your use case on https://github.com/aws/aws-sdk-js-codemod");
+    }
+    return specifier1LocalName.localeCompare(specifier2LocalName);
   }
 
   return 0;

--- a/src/transforms/v2-to-v3/modules/objectPatternPropertyCompareFn.ts
+++ b/src/transforms/v2-to-v3/modules/objectPatternPropertyCompareFn.ts
@@ -2,6 +2,7 @@ import type {
   ObjectProperty,
   Property,
   PropertyPattern,
+  RestElement,
   RestProperty,
   SpreadProperty,
   SpreadPropertyPattern,
@@ -13,6 +14,7 @@ export type ObjectPatternProperty =
   | SpreadPropertyPattern
   | SpreadProperty
   | ObjectProperty
+  | RestElement
   | RestProperty;
 
 export const objectPatternPropertyCompareFn = (

--- a/yarn.lock
+++ b/yarn.lock
@@ -1083,13 +1083,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/jscodeshift@npm:^0.12.0":
-  version: 0.12.0
-  resolution: "@types/jscodeshift@npm:0.12.0"
+"@types/jscodeshift@npm:^17.3.0":
+  version: 17.3.0
+  resolution: "@types/jscodeshift@npm:17.3.0"
   dependencies:
-    ast-types: "npm:^0.14.1"
-    recast: "npm:^0.20.3"
-  checksum: 10c0/18dea1a12f47daa35063c872a255a7239125187b172ce66639c326bd4b6a500fc8b44a98ec3a8e3fc502786658874a6b35850ac9f4effd9b9aacd1602b033feb
+    ast-types: "npm:^0.16.1"
+    recast: "npm:^0.23.11"
+  checksum: 10c0/56b889b290f12322b43d74c7434b69cef3e1ca8444e37891e08585f716b1c23f44596f650fb92220a8c6e5776d3dbc7d8ece67e950b6f9e733eee8e712128c73
   languageName: node
   linkType: hard
 
@@ -1176,15 +1176,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ast-types@npm:0.14.2, ast-types@npm:^0.14.1":
-  version: 0.14.2
-  resolution: "ast-types@npm:0.14.2"
-  dependencies:
-    tslib: "npm:^2.0.1"
-  checksum: 10c0/5d66d89b6c07fe092087454b6042dbaf81f2882b176db93861e2b986aafe0bce49e1f1ff59aac775d451c1426ad1e967d250e9e3548f5166ea8a3475e66c169d
-  languageName: node
-  linkType: hard
-
 "ast-types@npm:^0.16.1":
   version: 0.16.1
   resolution: "ast-types@npm:0.16.1"
@@ -1210,10 +1201,10 @@ __metadata:
     "@biomejs/biome": "npm:1.9.0"
     "@changesets/cli": "npm:^2.27.1"
     "@tsconfig/node18": "npm:^18.2.4"
-    "@types/jscodeshift": "npm:^0.12.0"
+    "@types/jscodeshift": "npm:^17.3.0"
     "@types/node": "npm:^18.19.112"
     aws-sdk: "npm:2.1692.0"
-    jscodeshift: "npm:17.1.1"
+    jscodeshift: "npm:17.3.0"
     tsx: "npm:^4.7.1"
     typescript: "npm:~5.8.3"
   bin:
@@ -2273,9 +2264,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jscodeshift@npm:17.1.1":
-  version: 17.1.1
-  resolution: "jscodeshift@npm:17.1.1"
+"jscodeshift@npm:17.3.0":
+  version: 17.3.0
+  resolution: "jscodeshift@npm:17.3.0"
   dependencies:
     "@babel/core": "npm:^7.24.7"
     "@babel/parser": "npm:^7.24.7"
@@ -2292,7 +2283,7 @@ __metadata:
     micromatch: "npm:^4.0.7"
     neo-async: "npm:^2.5.0"
     picocolors: "npm:^1.0.1"
-    recast: "npm:^0.23.9"
+    recast: "npm:^0.23.11"
     tmp: "npm:^0.2.3"
     write-file-atomic: "npm:^5.0.1"
   peerDependencies:
@@ -2302,7 +2293,7 @@ __metadata:
       optional: true
   bin:
     jscodeshift: bin/jscodeshift.js
-  checksum: 10c0/bd41e86e6cb6cd7dedb9a5b34740d1a44356e77c22fe70bd6ea20beb5bb4075c8bb2a372ba3d20a798931d678576895ec026f47b368677e0d2a29c5b5e6307bd
+  checksum: 10c0/366e3c8ec52597a00919c6eb37007b6bcde0037722b89bda0a4416aec36e34717a7c46d10b3e637ac0a2cf91b986e868063fd1e99a943699ac292f7aef78e3ba
   languageName: node
   linkType: hard
 
@@ -2834,19 +2825,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"recast@npm:^0.20.3":
-  version: 0.20.5
-  resolution: "recast@npm:0.20.5"
-  dependencies:
-    ast-types: "npm:0.14.2"
-    esprima: "npm:~4.0.0"
-    source-map: "npm:~0.6.1"
-    tslib: "npm:^2.0.1"
-  checksum: 10c0/7810216ff36c7376eddd66d3ce6b2df421305fdc983f2122711837911712177d52d804419655e1f29d4bb93016c178cffe442af410bdcf726050ca19af6fed32
-  languageName: node
-  linkType: hard
-
-"recast@npm:^0.23.9":
+"recast@npm:^0.23.11":
   version: 0.23.11
   resolution: "recast@npm:0.23.11"
   dependencies:


### PR DESCRIPTION
### Issue

* https://github.com/facebook/jscodeshift/releases/tag/v17.3.0
* Alternative to https://github.com/aws/aws-sdk-js-codemod/pull/991 without typecasting

### Description

Bumps jscodeshift to v17.3.0

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
