### PR TITLE
chore(deps-dev): bump @types/node to 18.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@changesets/cli": "^2.27.1",
     "@tsconfig/node18": "^18.2.4",
     "@types/jscodeshift": "^0.12.0",
-    "@types/node": "^16.18.101",
+    "@types/node": "^18.19.112",
     "aws-sdk": "2.1692.0",
     "tsx": "^4.7.1",
     "typescript": "~5.8.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1100,10 +1100,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:^16.18.101":
-  version: 16.18.126
-  resolution: "@types/node@npm:16.18.126"
-  checksum: 10c0/5c137eb141d33de32b16ff26047ff6d449432b58d0d25f7cced2040c97727d81fe1099a7581eb336d14a6840f5b09e363bdd43d7a6995e8e81eb47aa51e413fc
+"@types/node@npm:^18.19.112":
+  version: 18.19.112
+  resolution: "@types/node@npm:18.19.112"
+  dependencies:
+    undici-types: "npm:~5.26.4"
+  checksum: 10c0/e3421fb3c755337a0477014b235026d914cac8266b67de5867d778b2d4ce2ed0c8052c922e61810f2364d6b29ee24c6ea18671c5636076371b82b0d3e480fbef
   languageName: node
   linkType: hard
 
@@ -1209,7 +1211,7 @@ __metadata:
     "@changesets/cli": "npm:^2.27.1"
     "@tsconfig/node18": "npm:^18.2.4"
     "@types/jscodeshift": "npm:^0.12.0"
-    "@types/node": "npm:^16.18.101"
+    "@types/node": "npm:^18.19.112"
     aws-sdk: "npm:2.1692.0"
     jscodeshift: "npm:17.1.1"
     tsx: "npm:^4.7.1"
@@ -3242,6 +3244,13 @@ __metadata:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 10c0/39117e346ff8ebd87ae1510b3a77d5d92dae5a89bde588c747d25da5c146603a99c8ee588c7ef80faaf123d89ed46f6dbd918d534d641083177d5fac38b8a1cb
+  languageName: node
+  linkType: hard
+
+"undici-types@npm:~5.26.4":
+  version: 5.26.5
+  resolution: "undici-types@npm:5.26.5"
+  checksum: 10c0/bb673d7876c2d411b6eb6c560e0c571eef4a01c1c19925175d16e3a30c4c428181fb8d7ae802a261f283e4166a0ac435e2f505743aa9e45d893f9a3df017b501
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Issue

Missed in https://github.com/aws/aws-sdk-js-codemod/pull/987

### Description

Bumps @types/node to 18.x, as 16.x is no longer supported

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
