### PR TITLE
docs: require installing corepack and using yarn

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,11 +30,12 @@ To send us a pull request, please:
 
 1. Fork the repository.
 2. Use [ASTExplorer](https://astexplorer.net/) with category `JavaScript` and parser `acorn` for examining the AST.
-3. Modify the source; please focus on the specific change you are contributing.
-4. Ensure local tests pass.
-5. Commit to your fork using clear commit messages.
-6. Send us a pull request, answering any default questions in the pull request interface.
-7. Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.
+3. Globally install `npm i -g corepack`, and run `yarn` for installing dependencies.
+4. Modify the source; please focus on the specific change you are contributing.
+5. Ensure local tests pass.
+6. Commit to your fork using clear commit messages.
+7. Send us a pull request, answering any default questions in the pull request interface.
+8. Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.
 
 GitHub provides additional document on [forking a repository](https://help.github.com/articles/fork-a-repo/) and
 [creating a pull request](https://help.github.com/articles/creating-a-pull-request/).


### PR DESCRIPTION
### Issue

External contribution in https://github.com/aws/aws-sdk-js-codemod/pull/1000 removed `yarn.lock` and added `package-lock.json`

Contributors may not know our build setup, and instructions should be added in CONTRIBUTING.

### Description

Requires installing corepack and using yarn in CONTRIBUTING.md

### Testing

N/A

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
