### PR TITLE
chore(scripts): enable npm trusted publishing

### DIFF
--- a/.changeset/petite-cups-learn.md
+++ b/.changeset/petite-cups-learn.md
@@ -1,0 +1,5 @@
+---
+"aws-sdk-js-codemod": patch
+---
+
+Enable npm trusted publishing

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -22,6 +22,7 @@ jobs:
         with:
           cache: "yarn"
 
+      - run: npm install -g npm # Trusted publishing requires npm >=v11.5.1
       - run: yarn
 
       - name: Create Release Pull Request or Publish to npm
@@ -32,4 +33,3 @@ jobs:
           title: Publish <version>
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -63,8 +63,5 @@
       "version": "4.9.2",
       "onFail": "download"
     }
-  },
-  "publishConfig": {
-    "provenance": true
   }
 }


### PR DESCRIPTION
### Issue

https://docs.npmjs.com/trusted-publishers

### Description

Enables npm trusted publishing

npm package settings has Trusted publisher enabled for `aws/aws-sdk-js-codemod:push.yml` 

### Testing

Will be tested with v3.0.2 release after merging https://github.com/aws/aws-sdk-js-codemod/pull/1004

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
