### PR TITLE
fix(scripts): use node 24 for release

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -20,9 +20,9 @@ jobs:
         run: npm i -g corepack
       - uses: actions/setup-node@v4
         with:
+          node-version: "24.x" # Trusted publishing requires npm >=v11.5.1
           cache: "yarn"
 
-      - run: npm install -g npm # Trusted publishing requires npm >=v11.5.1
       - run: yarn
 
       - name: Create Release Pull Request or Publish to npm


### PR DESCRIPTION
### Issue

Release workflow is failing with error
```
Run npm install -g npm
npm error code EACCES
npm error syscall mkdir
npm error path /usr/local/share/man/man5
npm error errno -13
npm error Error: EACCES: permission denied, mkdir '/usr/local/share/man/man5'
npm error     at async mkdir (node:internal/fs/promises:858:10)
```
https://github.com/aws/aws-sdk-js-codemod/actions/runs/16817032709

### Description

Uses node 24 for release, as it comes with npm >=11.5.1

### Testing

Will be tested with v3.0.2 release after merging https://github.com/aws/aws-sdk-js-codemod/pull/1004

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
