### PR TITLE
fix(scripts): use packageManager field for yarn version

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,11 +57,5 @@
   "engines": {
     "node": ">=18.0.0"
   },
-  "devEngines": {
-    "packageManager": {
-      "name": "yarn",
-      "version": "4.9.2",
-      "onFail": "download"
-    }
-  }
+  "packageManager": "yarn@4.9.2"
 }


### PR DESCRIPTION
### Issue

Changeset users `npm` for publishing

When we attempted to use node 24 for publish step in https://github.com/aws/aws-sdk-js-codemod/pull/1006, the GitHub Action failed because of devEngines

```console
🦋  info npm info aws-sdk-js-codemod
🦋  error Received an unknown error code: EBADDEVENGINES for npm info "aws-sdk-js-codemod"
🦋  error The developer of this package has specified the following through devEngines
🦋  error Invalid engine "packageManager"
🦋  error Invalid name "yarn" does not match "npm" for "packageManager"
🦋  error [object Object]
```

https://github.com/aws/aws-sdk-js-codemod/actions/runs/16817222460/job/47636819313

### Description

Switches to using packageManager field for yarn version
```console
$ yarn set version 4.9.2 
```

Although `devEngines` is implemented by corepack, yarn continues to use packageManager field.
And as per Yarn Discord, it'll introduce it's own version manager soon.

### Testing

Publish will be tested post merge

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
